### PR TITLE
Better clean up of ragdolls and gibs.

### DIFF
--- a/sp/game/firefightreloaded/cfg/skill_firefightreloaded.cfg
+++ b/sp/game/firefightreloaded/cfg/skill_firefightreloaded.cfg
@@ -137,11 +137,11 @@ sk_plr_dmg_flare_round		"12"
 sk_npc_dmg_flare_round		"2"
 sk_max_flare_round			"999"
 
-sk_plr_dmg_knife "24"
-sk_npc_dmg_knife "24"
+sk_plr_dmg_knife "36"
+sk_npc_dmg_knife "36"
 
-sk_plr_dmg_knife_thrown "50"
-sk_npc_dmg_knife_thrown "50"
+sk_plr_dmg_knife_thrown "75"
+sk_npc_dmg_knife_thrown "75"
 
 sk_elitepolice_health	"45"
 

--- a/sp/game/firefightreloaded/scripts/shopcatalog_default.txt
+++ b/sp/game/firefightreloaded/scripts/shopcatalog_default.txt
@@ -18,6 +18,12 @@
 		"price"		"150"
 		"command"	"upgrade 0"
 	}
+        "32"
+        {
+		"name"		"Knife"
+		"price"		"300"
+		"command"	"item weapon_knife 0"
+        }
 	"4"
 	{
 		"name"		"PistolAmmo"

--- a/sp/game/firefightreloaded/scripts/weapon_knife.txt
+++ b/sp/game/firefightreloaded/scripts/weapon_knife.txt
@@ -11,8 +11,7 @@ WeaponData
 	"bucket"				"0"
 	"bucket_position"		"2"
 	
-	"clip_size"			"-1"
-
+	"clip_size"				"-1"
 	"primary_ammo"			"None"
 	"secondary_ammo"		"None"
 
@@ -24,7 +23,7 @@ WeaponData
 	"UseMuzzleSmoke"		"0"
 	"useironsights"			"0"
 	"LowerWeapon"			"0"
-	"useironsightcrosshair" 	"0"
+	"useironsightcrosshair" "0"
 	"MeleeWeapon"			"1"
 
 	// Sounds for the weapon. There is a max of 16 sounds per category (i.e. max 16 "single_shot" sounds)

--- a/sp/src/game/client/c_baseanimating.cpp
+++ b/sp/src/game/client/c_baseanimating.cpp
@@ -372,11 +372,6 @@ void C_ClientRagdoll::OnRestore( void )
 
 	SetNextClientThink( CLIENT_THINK_ALWAYS );
 	
-	if ( m_bFadeOut == true )
-	{
-		s_RagdollLRU.MoveToTopOfLRU( this, m_bImportant );
-	}
-
 	NoteRagdollCreationTick( this );
 	
 	BaseClass::OnRestore();
@@ -541,7 +536,7 @@ void C_ClientRagdoll::FadeOut( void )
 	}
 
 	int iAlpha = GetRenderColor().a;
-	int iFadeSpeed = ( g_RagdollLVManager.IsLowViolence() ) ? g_ragdoll_lvfadespeed.GetInt() : g_ragdoll_fadespeed.GetInt();
+	int iFadeSpeed = g_ragdoll_fadespeed.GetInt();
 
 	iAlpha = MAX( iAlpha - ( iFadeSpeed * gpGlobals->frametime ), 0 );
 
@@ -4661,13 +4656,6 @@ C_BaseAnimating *C_BaseAnimating::CreateRagdollCopy()
 	pRagdoll->IgniteRagdoll( this );
 	pRagdoll->TransferDissolveFrom( this );
 	pRagdoll->InitModelEffects();
-
-	if ( AddRagdollToFadeQueue() == true )
-	{
-		pRagdoll->m_bImportant = NPC_IsImportantNPC( this );
-		s_RagdollLRU.MoveToTopOfLRU( pRagdoll, pRagdoll->m_bImportant );
-		pRagdoll->m_bFadeOut = true;
-	}
 
 	m_builtRagdoll = true;
 	//AddEffects( EF_NODRAW );

--- a/sp/src/game/client/c_baseentity.cpp
+++ b/sp/src/game/client/c_baseentity.cpp
@@ -933,10 +933,8 @@ C_BaseEntity::C_BaseEntity() :
 	m_vecAbsVelocity.Init();
 	m_vecViewOffset.Init();
 	m_vecBaseVelocity.Init();
-
-	m_iCurrentThinkContext = NO_THINK_CONTEXT;
-
 #endif
+	m_iCurrentThinkContext = NO_THINK_CONTEXT;
 
 	m_nSimulationTick = -1;
 

--- a/sp/src/game/client/c_knife_bolt.cpp
+++ b/sp/src/game/client/c_knife_bolt.cpp
@@ -11,7 +11,7 @@
 #include "c_te_effect_dispatch.h"
 #include "beamdraw.h"
 
-CLIENTEFFECT_REGISTER_BEGIN( PrecacheEffectCrossbow )
+CLIENTEFFECT_REGISTER_BEGIN( PrecacheEffectKnife )
 CLIENTEFFECT_MATERIAL( "effects/muzzleflash1" )
 CLIENTEFFECT_REGISTER_END()
 
@@ -19,13 +19,13 @@ CLIENTEFFECT_REGISTER_END()
 // Crossbow bolt
 //
 
-class C_CrossbowBolt : public C_BaseCombatCharacter
+class C_KnifeBolt : public C_BaseCombatCharacter
 {
-	DECLARE_CLASS( C_CrossbowBolt, C_BaseCombatCharacter );
+	DECLARE_CLASS( C_KnifeBolt, C_BaseCombatCharacter );
 	DECLARE_CLIENTCLASS();
 public:
-	
-	C_CrossbowBolt( void );
+
+	C_KnifeBolt( void );
 
 	virtual RenderGroup_t GetRenderGroup( void )
 	{
@@ -40,19 +40,19 @@ public:
 
 private:
 
-	C_CrossbowBolt( const C_CrossbowBolt & ); // not defined, not accessible
+	C_KnifeBolt( const C_KnifeBolt & ); // not defined, not accessible
 
 	Vector	m_vecLastOrigin;
 	bool	m_bUpdated;
 };
 
-IMPLEMENT_CLIENTCLASS_DT( C_CrossbowBolt, DT_CrossbowBolt, CCrossbowBolt )
+IMPLEMENT_CLIENTCLASS_DT( C_KnifeBolt, DT_KnifeBolt, CKnifeBolt )
 END_RECV_TABLE()
 
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-C_CrossbowBolt::C_CrossbowBolt( void )
+C_KnifeBolt::C_KnifeBolt( void )
 {
 }
 
@@ -60,7 +60,7 @@ C_CrossbowBolt::C_CrossbowBolt( void )
 // Purpose: 
 // Input  : updateType - 
 //-----------------------------------------------------------------------------
-void C_CrossbowBolt::OnDataChanged( DataUpdateType_t updateType )
+void C_KnifeBolt::OnDataChanged( DataUpdateType_t updateType )
 {
 	BaseClass::OnDataChanged( updateType );
 
@@ -77,7 +77,7 @@ void C_CrossbowBolt::OnDataChanged( DataUpdateType_t updateType )
 // Input  : flags - 
 // Output : int
 //-----------------------------------------------------------------------------
-int C_CrossbowBolt::DrawModel( int flags )
+int C_KnifeBolt::DrawModel( int flags )
 {
 	// See if we're drawing the motion blur
 	if ( flags & STUDIO_TRANSPARENCY )
@@ -87,14 +87,14 @@ int C_CrossbowBolt::DrawModel( int flags )
 
 		Vector	vecDir = GetAbsOrigin() - m_vecLastOrigin;
 		float	speed = VectorNormalize( vecDir );
-		
+
 		speed = clamp( speed, 0, 32 );
-		
+
 		if ( speed > 0 )
 		{
-			float	stepSize = MIN( ( speed * 0.5f ), 4.0f );
+			float	stepSize = MIN( (speed * 0.5f), 4.0f );
 
-			Vector	spawnPos = GetAbsOrigin() + ( vecDir * 24.0f );
+			Vector	spawnPos = GetAbsOrigin() + (vecDir * 24.0f);
 			Vector	spawnStep = -vecDir * stepSize;
 
 			CMatRenderContextPtr pRenderContext( materials );
@@ -115,7 +115,7 @@ int C_CrossbowBolt::DrawModel( int flags )
 			}
 		}
 
-		if ( gpGlobals->frametime > 0.0f && !m_bUpdated)
+		if ( gpGlobals->frametime > 0.0f && !m_bUpdated )
 		{
 			m_bUpdated = true;
 			m_vecLastOrigin = GetAbsOrigin();
@@ -131,7 +131,7 @@ int C_CrossbowBolt::DrawModel( int flags )
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void C_CrossbowBolt::ClientThink( void )
+void C_KnifeBolt::ClientThink( void )
 {
 	m_bUpdated = false;
 }
@@ -140,12 +140,12 @@ void C_CrossbowBolt::ClientThink( void )
 // Purpose: 
 // Input  : &data - 
 //-----------------------------------------------------------------------------
-void CrossbowCrosshairLoadCallback( const CEffectData &data )
+void KnifeCrosshairLoadCallback( const CEffectData &data )
 {
-	IClientRenderable *pRenderable = data.GetRenderable( );
+	IClientRenderable *pRenderable = data.GetRenderable();
 	if ( !pRenderable )
 		return;
-	
+
 	Vector	position;
 	QAngle	angles;
 
@@ -156,4 +156,4 @@ void CrossbowCrosshairLoadCallback( const CEffectData &data )
 	}
 }
 
-DECLARE_CLIENT_EFFECT( "CrossbowLoad", CrossbowCrosshairLoadCallback );
+DECLARE_CLIENT_EFFECT( "KnifeLoad", KnifeCrosshairLoadCallback );

--- a/sp/src/game/client/c_stickybolt.cpp
+++ b/sp/src/game/client/c_stickybolt.cpp
@@ -126,29 +126,20 @@ private:
 	Vector  m_vWorld;
 };
 
-void CreateCrossbowBolt( const Vector &vecOrigin, const Vector &vecDirection, bool knifeMode = false )
+void CreateCrossbowBolt( const Vector &vecOrigin, const Vector &vecDirection )
 {
 	model_t* pModel = NULL;
 
-	if (knifeMode)
-	{
-		pModel = (model_t*)engine->LoadModel("models/knife_proj.mdl");
-	}
-	else
-	{
-		pModel = (model_t*)engine->LoadModel("models/crossbow_bolt.mdl");
-	}
+	pModel = (model_t*)engine->LoadModel("models/crossbow_bolt.mdl");
 
 	QAngle vAngles;
 
 	VectorAngles( vecDirection, vAngles );
-
-	float posKnife = (knifeMode ? 12 : 8);
 	
-	tempents->SpawnTempModel(pModel, vecOrigin - vecDirection * posKnife, vAngles, Vector(0, 0, 0), 30.0f, FTENT_NONE);
+	tempents->SpawnTempModel(pModel, vecOrigin - vecDirection * 8, vAngles, Vector(0, 0, 0), 30.0f, FTENT_NONE);
 }
 
-void StickRagdollNow( const Vector &vecOrigin, const Vector &vecDirection, bool knifeMode = false)
+void StickRagdollNow( const Vector &vecOrigin, const Vector &vecDirection)
 {
 	Ray_t	shotRay;
 	trace_t tr;
@@ -165,7 +156,7 @@ void StickRagdollNow( const Vector &vecOrigin, const Vector &vecDirection, bool 
 	CRagdollBoltEnumerator	ragdollEnum( shotRay, vecOrigin );
 	partition->EnumerateElementsAlongRay( PARTITION_CLIENT_RESPONSIVE_EDICTS, shotRay, false, &ragdollEnum );
 	
-	CreateCrossbowBolt( vecOrigin, vecDirection, knifeMode);
+	CreateCrossbowBolt( vecOrigin, vecDirection);
 }
 
 //-----------------------------------------------------------------------------
@@ -178,14 +169,3 @@ void StickyBoltCallback( const CEffectData &data )
 }
 
 DECLARE_CLIENT_EFFECT( "BoltImpact", StickyBoltCallback );
-
-//-----------------------------------------------------------------------------
-// Purpose: 
-// Input  : &data - 
-//-----------------------------------------------------------------------------
-void StickyKnifeCallback(const CEffectData& data)
-{
-	StickRagdollNow(data.m_vOrigin, data.m_vNormal, true);
-}
-
-DECLARE_CLIENT_EFFECT("KnifeImpact", StickyKnifeCallback);

--- a/sp/src/game/client/cdll_client_int.cpp
+++ b/sp/src/game/client/cdll_client_int.cpp
@@ -1771,9 +1771,6 @@ void CHLClient::LevelInitPreEntity( char const* pMapName )
 	}
 #endif
 
-	// Check low violence settings for this map
-	g_RagdollLVManager.SetLowViolence( pMapName );
-
 	gHUD.LevelInit();
 
 #if defined( REPLAY_ENABLED )

--- a/sp/src/game/client/fx_impact.cpp
+++ b/sp/src/game/client/fx_impact.cpp
@@ -15,6 +15,7 @@
 #endif
 #include "engine/IStaticPropMgr.h"
 #include "c_impact_effects.h"
+
 #include "tier0/vprof.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
@@ -72,9 +73,6 @@ IterationRetval_t CRagdollEnumerator::EnumElement( IHandleEntity *pHandleEntity 
 //-----------------------------------------------------------------------------
 bool FX_AffectRagdolls( Vector vecOrigin, Vector vecStart, int iDamageType )
 {
-	// don't do this when lots of ragdolls are simulating
-	if ( s_RagdollLRU.CountRagdolls(true) > 1 )
-		return false;
 	Ray_t shotRay;
 	shotRay.Init( vecStart, vecOrigin );
 

--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -10638,10 +10638,7 @@ CBaseEntity *CAI_BaseNPC::DropItem ( const char *pszItemName, Vector vecPos, QAn
 
 		static ConVarRef sv_cleanup_time( "sv_cleanup_time" );
 		if ( sv_cleanup_time.GetFloat() >= 0 )
-		{
-			RegisterThinkContext( "CleanUp" );
-			pItem->SetContextThink( &CBaseAnimating::CleanUp, gpGlobals->curtime + sv_cleanup_time.GetFloat(), "CleanUp" );
-		}
+			pItem->SUB_StartFadeOut( sv_cleanup_time.GetFloat(), false, "CleanUp" );
 
 		return pItem;
 	}

--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -120,8 +120,6 @@ extern ConVar sk_healthkit;
 
 //#define DEBUG_LOOK
 
-bool RagdollManager_SaveImportant( CAI_BaseNPC *pNPC );
-
 #define	MIN_PHYSICS_FLINCH_DAMAGE	5.0f
 
 #define	NPC_GRENADE_FEAR_DIST		200
@@ -606,11 +604,6 @@ void CAI_BaseNPC::Event_Killed( const CTakeDamageInfo &info )
 	}
 
 	BaseClass::Event_Killed( info );
-
-	if ( m_bFadeCorpse )
-	{
-		m_bImportanRagdoll = RagdollManager_SaveImportant( this );
-	}
 
 	/*if (m_pAttributes != NULL)
 	{
@@ -10652,15 +10645,8 @@ CBaseEntity *CAI_BaseNPC::DropItem ( const char *pszItemName, Vector vecPos, QAn
 
 bool CAI_BaseNPC::ShouldFadeOnDeath( void )
 {
-	if ( g_RagdollLVManager.IsLowViolence() )
-	{
-		return true;
-	}
-	else
-	{
-		// if flagged to fade out
-		return HasSpawnFlags(SF_NPC_FADE_CORPSE);
-	}
+	// if flagged to fade out
+	return HasSpawnFlags(SF_NPC_FADE_CORPSE);
 }
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -10629,9 +10629,9 @@ CBaseEntity *CAI_BaseNPC::DropItem ( const char *pszItemName, Vector vecPos, QAn
 			pItem->ApplyLocalAngularVelocityImpulse( AngularImpulse( 0, random->RandomFloat( 0, 100 ), 0 ) );
 		}
 
-		static ConVarRef sv_cleanup_time( "sv_cleanup_time" );
-		if ( sv_cleanup_time.GetFloat() >= 0 )
-			pItem->SUB_StartFadeOut( sv_cleanup_time.GetFloat(), false, "CleanUp" );
+		static ConVarRef sv_drops_cleanup_time( "sv_drops_cleanup_time" );
+		if ( sv_drops_cleanup_time.GetFloat() >= 0 )
+			pItem->SUB_StartFadeOut( sv_drops_cleanup_time.GetFloat(), false, "CleanUp" );
 
 		return pItem;
 	}

--- a/sp/src/game/server/baseanimating.cpp
+++ b/sp/src/game/server/baseanimating.cpp
@@ -215,8 +215,6 @@ DEFINE_INPUTFUNC( FIELD_VECTOR, "SetModelScale", InputSetModelScale ),
 
 DEFINE_FIELD( m_fBoneCacheFlags, FIELD_SHORT ),
 
-DEFINE_THINKFUNC( CleanUp ),
-
 	END_DATADESC()
 
 // Sendtable for fields we don't want to send to clientside animating entities

--- a/sp/src/game/server/baseanimating.cpp
+++ b/sp/src/game/server/baseanimating.cpp
@@ -263,7 +263,7 @@ SendPropFloat( SENDINFO( m_flFadeScale ), 0, SPROP_NOSCALE ),
 
 END_SEND_TABLE()
 
-ConVar sv_cleanup_time( "sv_cleanup_time", "60", FCVAR_ARCHIVE, "Time to clean up a dropped weapon/item." );
+ConVar sv_drops_cleanup_time( "sv_drops_cleanup_time", "60", FCVAR_ARCHIVE, "Time to clean up a dropped weapon/item." );
 
 CBaseAnimating::CBaseAnimating()
 {

--- a/sp/src/game/server/baseanimating.h
+++ b/sp/src/game/server/baseanimating.h
@@ -156,8 +156,6 @@ public:
 	bool	HasPoseParameter( int iSequence, int iParameter );
 	float	EdgeLimitPoseParameter( int iParameter, float flValue, float flBase = 0.0f );
 
-	void CleanUp( void ) { if ( GetParent() == NULL ) UTIL_Remove( this ); }
-
 protected:
 	// The modus operandi for pose parameters is that you should not use the const char * version of the functions
 	// in general code -- it causes many many string comparisons, which is slower than you think. Better is to 

--- a/sp/src/game/server/basecombatcharacter.cpp
+++ b/sp/src/game/server/basecombatcharacter.cpp
@@ -2040,9 +2040,9 @@ void CBaseCombatCharacter::Weapon_Drop( CBaseCombatWeapon *pWeapon, const Vector
 
 	pWeapon->Drop( vecThrow );
 	Weapon_Detach( pWeapon );
-	static ConVarRef sv_cleanup_time( "sv_cleanup_time" );
-	if ( sv_cleanup_time.GetFloat() >= 0 )
-		pWeapon->SUB_StartFadeOut( sv_cleanup_time.GetFloat(), false, "CleanUp" );
+	static ConVarRef sv_drops_cleanup_time( "sv_drops_cleanup_time" );
+	if ( sv_drops_cleanup_time.GetFloat() >= 0 )
+		pWeapon->SUB_StartFadeOut( sv_drops_cleanup_time.GetFloat(), false, "CleanUp" );
 
 	if ( HasSpawnFlags( SF_NPC_NO_WEAPON_DROP ) )
 	{

--- a/sp/src/game/server/basecombatcharacter.cpp
+++ b/sp/src/game/server/basecombatcharacter.cpp
@@ -2072,6 +2072,9 @@ void CBaseCombatCharacter::SetLightingOriginRelative( CBaseEntity *pLightingOrig
 //-----------------------------------------------------------------------------
 void CBaseCombatCharacter::Weapon_Equip( CBaseCombatWeapon *pWeapon )
 {
+	// Don't clean up this weapon anymore.
+	pWeapon->ThinkSet( NULL, 0, "CleanUp" );
+
 	// Add the weapon to my weapon inventory
 	for (int i=0;i<MAX_WEAPONS;i++) 
 	{

--- a/sp/src/game/server/basecombatcharacter.cpp
+++ b/sp/src/game/server/basecombatcharacter.cpp
@@ -2884,6 +2884,9 @@ CBaseEntity *CBaseCombatCharacter::Weapon_FindUsable( const Vector &range )
 		Assert(pWeapon);
 		pWeapon->GetVelocity( &velocity, NULL );
 
+		if ( pWeapon->IsEffectActive( EF_NODRAW ) )
+			continue;
+
 		if ( pWeapon->CanBePickedUpByNPCs() == false )
 			continue;
 

--- a/sp/src/game/server/basecombatcharacter.cpp
+++ b/sp/src/game/server/basecombatcharacter.cpp
@@ -2042,10 +2042,7 @@ void CBaseCombatCharacter::Weapon_Drop( CBaseCombatWeapon *pWeapon, const Vector
 	Weapon_Detach( pWeapon );
 	static ConVarRef sv_cleanup_time( "sv_cleanup_time" );
 	if ( sv_cleanup_time.GetFloat() >= 0 )
-	{
-		RegisterThinkContext( "CleanUp" );
-		pWeapon->SetContextThink( &CBaseAnimating::CleanUp, gpGlobals->curtime + sv_cleanup_time.GetFloat(), "CleanUp" );
-	}
+		pWeapon->SUB_StartFadeOut( sv_cleanup_time.GetFloat(), false, "CleanUp" );
 
 	if ( HasSpawnFlags( SF_NPC_NO_WEAPON_DROP ) )
 	{

--- a/sp/src/game/server/baseentity.cpp
+++ b/sp/src/game/server/baseentity.cpp
@@ -382,9 +382,7 @@ CBaseEntity::CBaseEntity( bool bServerOnly )
 	m_nSimulationTick = -1;
 	SetIdentityMatrix( m_rgflCoordinateFrame );
 	m_pBlocker = NULL;
-#if _DEBUG
 	m_iCurrentThinkContext = NO_THINK_CONTEXT;
-#endif
 	m_nWaterTouch = m_nSlimeTouch = 0;
 
 	SetSolid( SOLID_NONE );
@@ -7127,10 +7125,9 @@ void CBaseEntity::RemoveDeferred( void )
 //
 // DON'T USE ME FOR GIBS AND STUFF IN MULTIPLAYER!
 // SET A FUTURE THINK AND A RENDERMODE!!
-void CBaseEntity::SUB_StartFadeOut( float delay, bool notSolid )
+void CBaseEntity::SUB_StartFadeOut( float delay, bool notSolid, const char* context )
 {
-	SetThink( &CBaseEntity::SUB_FadeOut );
-	SetNextThink( gpGlobals->curtime + delay );
+	ThinkSet( &CBaseEntity::SUB_FadeOut, gpGlobals->curtime + delay, context );
 	SetRenderColorA( 255 );
 	m_nRenderMode = kRenderNormal;
 
@@ -7210,14 +7207,6 @@ bool CBaseEntity::SUB_AllowedToFade( void )
 			return false;
 	}
 
-	// on Xbox, allow these to fade out
-#ifndef _XBOX
-	CBasePlayer *pPlayer = UTIL_GetNearestVisiblePlayer(this);
-
-	if ( pPlayer && pPlayer->FInViewCone( this ) )
-		return false;
-#endif
-
 	return true;
 }
 
@@ -7228,7 +7217,7 @@ void CBaseEntity::SUB_FadeOut( void  )
 {
 	if ( SUB_AllowedToFade() == false )
 	{
-		SetNextThink( gpGlobals->curtime + 1 );
+		SetNextThink( m_iCurrentThinkContext, gpGlobals->curtime + 1 );
 		SetRenderColorA( 255 );
 		return;
 	}
@@ -7241,7 +7230,7 @@ void CBaseEntity::SUB_FadeOut( void  )
 	}
 	else
 	{
-		SetNextThink( gpGlobals->curtime );
+		SetNextThink( m_iCurrentThinkContext, gpGlobals->curtime );
 	}
 }
 

--- a/sp/src/game/server/baseentity.h
+++ b/sp/src/game/server/baseentity.h
@@ -839,9 +839,7 @@ protected:
 	int		GetIndexForThinkContext( const char *pszContext );
 	CUtlVector< thinkfunc_t >	m_aThinkFunctions;
 
-#ifdef _DEBUG
 	int							m_iCurrentThinkContext;
-#endif
 
 	void RemoveExpiredConcepts( void );
 	int	GetContextCount() const;						// Call RemoveExpiredConcepts to clean out expired concepts
@@ -1046,7 +1044,7 @@ public:
 	// common member functions
 	void					SUB_Remove( void );
 	void					SUB_DoNothing( void );
-	void					SUB_StartFadeOut( float delay = 10.0f, bool bNotSolid = true );
+	void					SUB_StartFadeOut( float delay = 10.0f, bool bNotSolid = true, const char* context = NULL );
 	void					SUB_StartFadeOutInstant();
 	void					SUB_FadeOut ( void );
 	void					SUB_Vanish( void );

--- a/sp/src/game/server/firefightreloaded/cleanup_manager.cpp
+++ b/sp/src/game/server/firefightreloaded/cleanup_manager.cpp
@@ -34,15 +34,6 @@ void CCleanupManager::Add( Handles& handles, EHANDLE handle, const ConVar& var, 
 	if ( var.GetInt() < 0 || handle == NULL )
 		return;
 
-	for ( int i = 0; i < handles.Count(); ++i )
-	{
-		if ( handles[i] == NULL )
-		{
-			handles[i] = handle;
-			return;
-		}
-	}
-
 	while ( handles.Count() >= var.GetInt() )
 	{
 		auto handle = handles.Head();

--- a/sp/src/game/server/firefightreloaded/cleanup_manager.cpp
+++ b/sp/src/game/server/firefightreloaded/cleanup_manager.cpp
@@ -56,7 +56,7 @@ void CCleanupManager::AddGib( EHANDLE gib )
 
 void CCleanupManager::AddRagdoll( EHANDLE ragdoll )
 {
-	Add( GetManager()->m_Ragdolls, ragdoll, g_max_thrown_knives, true );
+	Add( GetManager()->m_Ragdolls, ragdoll, g_ragdoll_maxcount, true );
 }
 
 void CCleanupManager::AddThrownKnife( EHANDLE knife )

--- a/sp/src/game/server/firefightreloaded/cleanup_manager.cpp
+++ b/sp/src/game/server/firefightreloaded/cleanup_manager.cpp
@@ -31,17 +31,25 @@ CCleanupManager* CCleanupManager::GetManager()
 
 void CCleanupManager::Add( Handles& handles, EHANDLE handle, const ConVar& var, bool bNotSolid )
 {
-	if ( !handle.IsValid() )
+	if ( var.GetInt() < 0 || handle == NULL )
 		return;
+
+	for ( int i = 0; i < handles.Count(); ++i )
+	{
+		if ( handles[i] == NULL )
+		{
+			handles[i] = handle;
+			return;
+		}
+	}
 
 	while ( handles.Count() >= var.GetInt() )
 	{
 		auto handle = handles.Head();
 		handles.Remove( 0 );
-		if ( handle.IsValid() )
+		if ( handle != NULL )
 			handle->SUB_StartFadeOut( 0, bNotSolid, "cleanup" );
 	}
-
 	handles.AddToTail( handle );
 }
 

--- a/sp/src/game/server/firefightreloaded/cleanup_manager.cpp
+++ b/sp/src/game/server/firefightreloaded/cleanup_manager.cpp
@@ -1,0 +1,81 @@
+#include "cbase.h"
+#include "saverestore_utlvector.h"
+#include "cleanup_manager.h"
+
+ConVar g_max_combine_mines( "g_max_combine_mines", "32", FCVAR_REPLICATED, "Maximum number of hoppers dropped by scanners." );
+ConVar g_max_gib_pieces( "g_max_gib_pieces", "32", FCVAR_REPLICATED, "Maximum number of gibs." );
+ConVar g_max_thrown_knives( "g_max_thrown_knives", "32", FCVAR_REPLICATED, "Maximum number of thrown knives." );
+ConVar g_ragdoll_maxcount( "g_ragdoll_maxcount", "32", FCVAR_REPLICATED, "Maximum number of ragdolls." );
+
+BEGIN_DATADESC( CCleanupManager )
+DEFINE_UTLVECTOR( m_CombineMines, FIELD_EHANDLE ),
+DEFINE_UTLVECTOR( m_Gibs, FIELD_EHANDLE ),
+DEFINE_UTLVECTOR( m_Ragdolls, FIELD_EHANDLE ),
+DEFINE_UTLVECTOR( m_ThrownKnives, FIELD_EHANDLE ),
+END_DATADESC()
+
+LINK_ENTITY_TO_CLASS( ffr_cleanup_manager, CCleanupManager )
+
+CCleanupManager* CCleanupManager::pManager;
+
+CCleanupManager* CCleanupManager::GetManager()
+{
+	if ( pManager == NULL )
+	{
+		pManager = (CCleanupManager*)gEntList.FindEntityByClassname( NULL, "ffr_cleanup_manager" );
+		if ( pManager == NULL )
+			pManager = (CCleanupManager*)CBaseEntity::Create( "ffr_cleanup_manager", vec3_origin, vec3_angle );
+	}
+	return pManager;
+}
+
+void CCleanupManager::Add( Handles& handles, EHANDLE handle, const ConVar& var, bool bNotSolid )
+{
+	if ( !handle.IsValid() )
+		return;
+
+	while ( handles.Count() >= var.GetInt() )
+	{
+		auto handle = handles.Head();
+		handles.Remove( 0 );
+		if ( handle.IsValid() )
+			handle->SUB_StartFadeOut( 0, bNotSolid, "cleanup" );
+	}
+
+	handles.AddToTail( handle );
+}
+
+void CCleanupManager::AddCombineMine( EHANDLE mine )
+{
+	Add( GetManager()->m_CombineMines, mine, g_max_combine_mines, true );
+}
+
+void CCleanupManager::AddGib( EHANDLE gib )
+{
+	Add( GetManager()->m_Gibs, gib, g_max_gib_pieces, true );
+}
+
+void CCleanupManager::AddRagdoll( EHANDLE ragdoll )
+{
+	Add( GetManager()->m_Ragdolls, ragdoll, g_max_thrown_knives, true );
+}
+
+void CCleanupManager::AddThrownKnife( EHANDLE knife )
+{
+	Add( GetManager()->m_ThrownKnives, knife, g_max_thrown_knives, false );
+}
+
+bool CCleanupManager::RemoveCombineMine( EHANDLE mine )
+{
+	return GetManager()->m_CombineMines.FindAndRemove( mine );
+}
+
+bool CCleanupManager::RemoveThrownKnife( EHANDLE knife )
+{
+	return GetManager()->m_ThrownKnives.FindAndRemove( knife );
+}
+
+void CCleanupManager::Shutdown()
+{
+	pManager = NULL;
+}

--- a/sp/src/game/server/firefightreloaded/cleanup_manager.h
+++ b/sp/src/game/server/firefightreloaded/cleanup_manager.h
@@ -1,0 +1,43 @@
+#ifndef CLEANUP
+#define CLEANUP
+#include "cbase.h"
+#include "utlvector.h"
+
+// memdbgon must be the last include file in a .cpp file!!!
+#include "tier0/memdbgon.h"
+
+extern ConVar g_max_gib_pieces;
+extern ConVar g_max_thrown_knives;
+extern ConVar g_ragdoll_maxcount;
+
+class CCleanupManager : public CBaseEntity
+{
+	DECLARE_CLASS(CCleanupManager, CBaseEntity)
+	DECLARE_DATADESC()
+
+	typedef CUtlVector<EHANDLE> Handles;
+	Handles m_CombineMines;
+	Handles m_Gibs;
+	Handles m_Ragdolls;
+	Handles m_ThrownKnives;
+
+	static CCleanupManager* pManager;
+	static CCleanupManager* GetManager();
+
+	static void Add( Handles& handles, EHANDLE handle, const ConVar& var, bool bNotSolid );
+
+public:
+	CCleanupManager() {}
+
+	static void AddCombineMine( EHANDLE mine );
+	static void AddGib( EHANDLE gib );
+	static void AddRagdoll( EHANDLE ragdoll );
+	static void AddThrownKnife( EHANDLE knife );
+
+	static bool RemoveCombineMine( EHANDLE mine );
+	static bool RemoveThrownKnife( EHANDLE knife );
+
+	static void Shutdown();
+};
+
+#endif

--- a/sp/src/game/server/firefightreloaded/cleanup_manager.h
+++ b/sp/src/game/server/firefightreloaded/cleanup_manager.h
@@ -6,6 +6,7 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
+extern ConVar g_max_combine_mines;
 extern ConVar g_max_gib_pieces;
 extern ConVar g_max_thrown_knives;
 extern ConVar g_ragdoll_maxcount;

--- a/sp/src/game/server/firefightreloaded/cleanup_manager.h
+++ b/sp/src/game/server/firefightreloaded/cleanup_manager.h
@@ -28,8 +28,6 @@ class CCleanupManager : public CBaseEntity
 	static void Add( Handles& handles, EHANDLE handle, const ConVar& var, bool bNotSolid );
 
 public:
-	CCleanupManager() {}
-
 	static void AddCombineMine( EHANDLE mine );
 	static void AddGib( EHANDLE gib );
 	static void AddRagdoll( EHANDLE ragdoll );

--- a/sp/src/game/server/firefightreloaded/item_armortypes.cpp
+++ b/sp/src/game/server/firefightreloaded/item_armortypes.cpp
@@ -26,6 +26,7 @@ public:
 		SetModel( "models/items/hevsuit_lightarmor.mdl" );
 		BaseClass::Spawn( );
 		SetSolid( SOLID_NONE );
+		AddSolidFlags( FSOLID_NOT_SOLID );
 	}
 	void Precache( void )
 	{
@@ -55,6 +56,7 @@ public:
 		SetModel("models/items/hevsuit_heavyarmor.mdl");
 		BaseClass::Spawn();
 		SetSolid( SOLID_NONE );
+		AddSolidFlags( FSOLID_NOT_SOLID );
 	}
 	void Precache(void)
 	{
@@ -82,7 +84,6 @@ public:
 	{
 		Precache();
 		SetModel("models/armor/shield.mdl");
-		AddSpawnFlags(SF_NORESPAWN);
 		BaseClass::Spawn();
 	}
 	void Precache(void)

--- a/sp/src/game/server/firefightreloaded/item_armortypes.cpp
+++ b/sp/src/game/server/firefightreloaded/item_armortypes.cpp
@@ -25,8 +25,6 @@ public:
 		Precache( );
 		SetModel( "models/items/hevsuit_lightarmor.mdl" );
 		BaseClass::Spawn( );
-		SetSolid( SOLID_NONE );
-		AddSolidFlags( FSOLID_NOT_SOLID );
 	}
 	void Precache( void )
 	{
@@ -55,8 +53,6 @@ public:
 		Precache();
 		SetModel("models/items/hevsuit_heavyarmor.mdl");
 		BaseClass::Spawn();
-		SetSolid( SOLID_NONE );
-		AddSolidFlags( FSOLID_NOT_SOLID );
 	}
 	void Precache(void)
 	{

--- a/sp/src/game/server/firefightreloaded/item_armortypes.cpp
+++ b/sp/src/game/server/firefightreloaded/item_armortypes.cpp
@@ -25,6 +25,7 @@ public:
 		Precache( );
 		SetModel( "models/items/hevsuit_lightarmor.mdl" );
 		BaseClass::Spawn( );
+		SetSolid( SOLID_NONE );
 	}
 	void Precache( void )
 	{
@@ -53,6 +54,7 @@ public:
 		Precache();
 		SetModel("models/items/hevsuit_heavyarmor.mdl");
 		BaseClass::Spawn();
+		SetSolid( SOLID_NONE );
 	}
 	void Precache(void)
 	{

--- a/sp/src/game/server/firefightreloaded/item_itemcrate_firefight.cpp
+++ b/sp/src/game/server/firefightreloaded/item_itemcrate_firefight.cpp
@@ -349,7 +349,7 @@ void CItem_ItemCrateFirefight::OnBreak( const Vector &vecVelocity, const Angular
 
 		pSpawn->Spawn();
 
-		static ConVarRef sv_cleanup_time( "sv_cleanup_time" );
+		static ConVarRef sv_drops_cleanup_time( "sv_drops_cleanup_time" );
 
 		// Avoid missing items drops by a dynamic resupply because they don't think immediately
 		if ( FClassnameIs( pSpawn, "item_dynamic_resupply" ) )
@@ -364,8 +364,8 @@ void CItem_ItemCrateFirefight::OnBreak( const Vector &vecVelocity, const Angular
 			}
 			pSpawn->SetNextThink( gpGlobals->curtime );
 		}
-		else if ( shouldRespawn && sv_cleanup_time.GetFloat() >= 0 )
-			pSpawn->SUB_StartFadeOut( sv_cleanup_time.GetFloat(), false, "CleanUp" );
+		else if ( shouldRespawn && sv_drops_cleanup_time.GetFloat() >= 0 )
+			pSpawn->SUB_StartFadeOut( sv_drops_cleanup_time.GetFloat(), false, "CleanUp" );
 
 		if (shouldRespawn || m_bDoNotRespawnContents)
 			pSpawn->AddSpawnFlags(SF_NORESPAWN);

--- a/sp/src/game/server/firefightreloaded/item_itemcrate_firefight.cpp
+++ b/sp/src/game/server/firefightreloaded/item_itemcrate_firefight.cpp
@@ -274,6 +274,7 @@ void CItem_ItemCrateFirefight::VPhysicsCollision( int index, gamevcollisionevent
 //-----------------------------------------------------------------------------
 void CItem_ItemCrateFirefight::OnBreak( const Vector &vecVelocity, const AngularImpulse &angImpulse, CBaseEntity *pBreaker )
 {
+	// Should this crate respawn?
 	bool shouldRespawn = !m_bDoNotRespawn && sv_crate_respawn_time.GetFloat() >= 0;
 
 	// FIXME: We could simply store the name of an entity to put into the crate 
@@ -363,11 +364,8 @@ void CItem_ItemCrateFirefight::OnBreak( const Vector &vecVelocity, const Angular
 			}
 			pSpawn->SetNextThink( gpGlobals->curtime );
 		}
-		else if ( sv_cleanup_time.GetFloat() >= 0 )
-		{
-			RegisterThinkContext( "CleanUp" );
-			pSpawn->SetContextThink( &CBaseAnimating::CleanUp, gpGlobals->curtime + sv_cleanup_time.GetFloat(), "CleanUp" );
-		}
+		else if ( shouldRespawn && sv_cleanup_time.GetFloat() >= 0 )
+			pSpawn->SUB_StartFadeOut( sv_cleanup_time.GetFloat(), false, "CleanUp" );
 
 		if (shouldRespawn || m_bDoNotRespawnContents)
 			pSpawn->AddSpawnFlags(SF_NORESPAWN);

--- a/sp/src/game/server/firefightreloaded/knife_bolt.cpp
+++ b/sp/src/game/server/firefightreloaded/knife_bolt.cpp
@@ -21,6 +21,7 @@
 #include "hl2_player.h"
 #include "func_break.h"
 #include "func_breakablesurf.h"
+#include "cleanup_manager.h"
 
 #ifdef PORTAL
 #include "portal_util_shared.h"
@@ -268,7 +269,7 @@ void CKnifeBolt::BoltTouch( CBaseEntity *pOther )
 
 		SetAbsVelocity( Vector( 0, 0, 0 ) );
 
-		// play body "thwack" sound
+		// play body "thwack" sound 
 		EmitSound( "Weapon_Crossbow.BoltHitBody" );
 
 		Vector vForward;
@@ -386,6 +387,8 @@ void CKnifeBolt::DoneMoving( bool stuck )
 	}
 	pWeap->SetAbsVelocity( Vector( 0, 0, 0 ) );
 	pWeap->AddEffects( EF_ITEM_BLINK );
+
+	CCleanupManager::AddThrownKnife( pWeap );
 
 	Remove();
 }

--- a/sp/src/game/server/firefightreloaded/knife_bolt.cpp
+++ b/sp/src/game/server/firefightreloaded/knife_bolt.cpp
@@ -187,10 +187,10 @@ void CKnifeBolt::Precache( void )
 //-----------------------------------------------------------------------------
 void CKnifeBolt::BoltTouch( CBaseEntity *pOther )
 {
-	if ( pOther->IsSolidFlagSet( FSOLID_VOLUME_CONTENTS | FSOLID_TRIGGER ) )
+	if ( pOther->IsSolidFlagSet( FSOLID_VOLUME_CONTENTS | FSOLID_TRIGGER ) && !pOther->IsSolidFlagSet(FSOLID_USE_TRIGGER_BOUNDS) )
 	{
 		// Some NPCs are triggers that can take damage (like antlion grubs). We should hit them.
-		if ( (pOther->m_takedamage == DAMAGE_NO) || (pOther->m_takedamage == DAMAGE_EVENTS_ONLY) )
+		if ( (pOther->m_takedamage == DAMAGE_NO || pOther->m_takedamage == DAMAGE_EVENTS_ONLY) )
 			return;
 	}
 

--- a/sp/src/game/server/firefightreloaded/weapon_knife.cpp
+++ b/sp/src/game/server/firefightreloaded/weapon_knife.cpp
@@ -140,15 +140,15 @@ void CWeaponKnife::ThrowKnife(void)
 
 void CWeaponKnife::SecondaryAttack(void)
 {
-	ThrowKnife();
-
 	CBasePlayer* pPlayer = ToBasePlayer(GetOwner());
 	if (pPlayer)
 	{
 		m_iSecondaryAttacks++;
 		gamestats->Event_WeaponFired(pPlayer, true, GetClassname());
-		//pPlayer->SwitchToNextBestWeapon(this);
-		engine->ClientCommand(pPlayer->edict(), "lastinv");
+		ThrowKnife();
+		pPlayer->Weapon_Detach( this );
+		Remove();
+		engine->ClientCommand( pPlayer->edict(), "lastinv" );
 	}
 }
 

--- a/sp/src/game/server/firefightreloaded/weapon_knife.cpp
+++ b/sp/src/game/server/firefightreloaded/weapon_knife.cpp
@@ -379,3 +379,20 @@ void CWeaponKnife::ImpactEffect(trace_t &traceHit)
 	UTIL_ImpactTrace(&traceHit, DMG_SLASH);
 	//UTIL_DecalTrace(&traceHit, "ManhackCut");
 }
+
+int CWeaponKnife::OnTakeDamage( const CTakeDamageInfo& info )
+{
+	auto phys = VPhysicsGetObject();
+	if ( IsEffectActive( EF_ITEM_BLINK ) && phys != NULL && !phys->IsMotionEnabled() )
+	{
+		Vector forward;
+		AngleVectors( GetAbsAngles(), &forward );
+		phys->EnableMotion( true );
+		phys->Wake();
+		forward *= Clamp( info.GetDamage() + 100, 100.0f, 250.0f );
+		phys->SetVelocity( &forward, NULL );
+		return 0;
+	}
+	else
+		return BaseClass::OnTakeDamage( info );
+}

--- a/sp/src/game/server/firefightreloaded/weapon_knife.cpp
+++ b/sp/src/game/server/firefightreloaded/weapon_knife.cpp
@@ -71,11 +71,6 @@ CWeaponKnife::CWeaponKnife( void )
 {
 }
 
-/*void CWeaponKnife::Precache(void)
-{
-	UTIL_PrecacheOther("knife_bolt");
-}*/
-
 bool CWeaponKnife::Deploy(void)
 {
 	bool deployVal = BaseClass::Deploy();
@@ -147,8 +142,9 @@ void CWeaponKnife::SecondaryAttack(void)
 		gamestats->Event_WeaponFired(pPlayer, true, GetClassname());
 		ThrowKnife();
 		pPlayer->Weapon_Detach( this );
-		Remove();
 		engine->ClientCommand( pPlayer->edict(), "lastinv" );
+		engine->ClientCommand( pPlayer->edict(), "-attack2" );
+		UTIL_Remove( this );
 	}
 }
 

--- a/sp/src/game/server/firefightreloaded/weapon_knife.cpp
+++ b/sp/src/game/server/firefightreloaded/weapon_knife.cpp
@@ -91,7 +91,6 @@ bool CWeaponKnife::Deploy(void)
 
 #define THROWNKNIFE_AIR_VELOCITY	2500
 #define THROWNKNIFE_WATER_VELOCITY	1500
-#define	SF_BOLT_KNIFEMODE			0x00000001
 void CWeaponKnife::ThrowKnife(void)
 {
 	CBasePlayer* pOwner = ToBasePlayer(GetOwner());
@@ -109,7 +108,6 @@ void CWeaponKnife::ThrowKnife(void)
 	CBaseEntity* pBolt = CreateEntityByName("knife_bolt");
 	UTIL_SetOrigin(pBolt, vecSrc);
 	pBolt->SetAbsAngles(angAiming);
-	pBolt->AddSpawnFlags(SF_BOLT_KNIFEMODE);
 	pBolt->Spawn();
 	pBolt->SetOwnerEntity(pOwner);
 

--- a/sp/src/game/server/firefightreloaded/weapon_knife.h
+++ b/sp/src/game/server/firefightreloaded/weapon_knife.h
@@ -44,7 +44,6 @@ public:
 	void 		ThrowKnife(void);
 	virtual int WeaponMeleeAttack1Condition( float flDot, float flDist );
 	void		SecondaryAttack(void);
-	//void 		Precache(void);
 	bool		Deploy(void);
 	void		ItemPostFrame(void);
 

--- a/sp/src/game/server/firefightreloaded/weapon_knife.h
+++ b/sp/src/game/server/firefightreloaded/weapon_knife.h
@@ -49,6 +49,8 @@ public:
 
 	int			OnTakeDamage( const CTakeDamageInfo& info );
 
+	virtual void Equip( CBaseCombatCharacter *pOwner );
+
 	// Animation event
 	virtual void Operator_HandleAnimEvent( animevent_t *pEvent, CBaseCombatCharacter *pOperator );
 	void			Hit(trace_t &traceHit, Activity nHitActivity, bool bIsSecondary);

--- a/sp/src/game/server/firefightreloaded/weapon_knife.h
+++ b/sp/src/game/server/firefightreloaded/weapon_knife.h
@@ -47,6 +47,8 @@ public:
 	bool		Deploy(void);
 	void		ItemPostFrame(void);
 
+	int			OnTakeDamage( const CTakeDamageInfo& info );
+
 	// Animation event
 	virtual void Operator_HandleAnimEvent( animevent_t *pEvent, CBaseCombatCharacter *pOperator );
 	void			Hit(trace_t &traceHit, Activity nHitActivity, bool bIsSecondary);

--- a/sp/src/game/server/gameinterface.cpp
+++ b/sp/src/game/server/gameinterface.cpp
@@ -91,6 +91,7 @@
 #include "querycache.h"
 #include "SMMOD/mapadd.h"
 #include "firefightreloaded/randnpcloader.h"
+#include "firefightreloaded/cleanup_manager.h"
 
 
 #ifdef TF_DLL
@@ -1048,9 +1049,6 @@ bool CServerGameDLL::LevelInit( const char *pMapName, char const *pMapEntities, 
 		LevelInit_ParseAllEntities( pMapEntities );
 	}
 
-	// Check low violence settings for this map
-	g_RagdollLVManager.SetLowViolence( pMapName );
-
 	// Now that all of the active entities have been loaded in, precache any entities who need point_template parameters
 	//  to be parsed (the above code has loaded all point_template entities)
 	PrecachePointTemplates();
@@ -1392,6 +1390,8 @@ void CServerGameDLL::LevelShutdown( void )
 		delete g_npcLoader;
 		g_npcLoader = NULL;
 	}
+
+	CCleanupManager::Shutdown();
 
 	InvalidateQueryCache();
 

--- a/sp/src/game/server/gib.cpp
+++ b/sp/src/game/server/gib.cpp
@@ -293,7 +293,7 @@ void CGib::SpawnSpecificGibs(CBaseEntity*	pVictim,
 	for (int i = 0; i<nNumGibs; i++)
 	{
 		CGib *pGib = CREATE_ENTITY(CGib, "gib");
-		pGib->Spawn(cModelName);
+		pGib->Spawn(cModelName, flLifetime);
 		pGib->m_nBody = i;
 		pGib->InitGib(pVictim, vMinVelocity, vMaxVelocity);
 		pGib->m_lifeTime = flLifetime;
@@ -506,13 +506,6 @@ bool CGib::SUB_AllowedToFade(void)
 	{
 		if (VPhysicsGetObject()->GetGameFlags() & FVPHYSICS_PLAYER_HELD || GetEFlags() & EFL_IS_BEING_LIFTED_BY_BARNACLE)
 			return false;
-	}
-
-	CBasePlayer *pPlayer = (AI_IsSinglePlayer()) ? UTIL_GetLocalPlayer() : NULL;
-
-	if (pPlayer && pPlayer->FInViewCone(this) && m_bForceRemove == false)
-	{
-		return false;
 	}
 
 	return true;

--- a/sp/src/game/server/hl2/combine_mine.cpp
+++ b/sp/src/game/server/hl2/combine_mine.cpp
@@ -17,6 +17,7 @@
 #include "movevars_shared.h"
 #include "vphysics/constraints.h"
 #include "ai_hint.h"
+#include "firefightreloaded/cleanup_manager.h"
 
 enum
 {
@@ -1168,6 +1169,7 @@ void CBounceBomb::InputDisarm( inputdata_t &inputdata )
 //---------------------------------------------------------
 void CBounceBomb::OnPhysGunDrop( CBasePlayer *pPhysGunUser, PhysGunDrop_t Reason )
 {
+	CCleanupManager::RemoveCombineMine( this );
 	m_hPhysicsAttacker = pPhysGunUser;
 
 	m_flTimeGrabbed = FLT_MAX;
@@ -1198,6 +1200,7 @@ void CBounceBomb::OnPhysGunDrop( CBasePlayer *pPhysGunUser, PhysGunDrop_t Reason
 //---------------------------------------------------------
 void CBounceBomb::OnPhysGunPickup( CBasePlayer *pPhysGunUser, PhysGunPickup_t reason )
 {
+	CCleanupManager::RemoveCombineMine( this );
 	m_hPhysicsAttacker = pPhysGunUser;
 
 	m_iFlipAttempts = 0;

--- a/sp/src/game/server/hl2/npc_scanner.cpp
+++ b/sp/src/game/server/hl2/npc_scanner.cpp
@@ -24,6 +24,7 @@
 #include "hl2_player.h"
 #include "npc_scanner.h"
 #include "materialsystem/imaterialsystemhardwareconfig.h"
+#include "firefightreloaded/cleanup_manager.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -980,6 +981,7 @@ void CNPC_CScanner::DeployMine()
 			child->SetParent( NULL );
 			child->SetAbsVelocity( GetAbsVelocity() );
 			child->SetOwnerEntity( this );
+			CCleanupManager::AddCombineMine( this );
 
 			ScannerEmitSound( "DeployMine" );
 

--- a/sp/src/game/server/hl2/npc_scanner.cpp
+++ b/sp/src/game/server/hl2/npc_scanner.cpp
@@ -330,7 +330,8 @@ int CNPC_CScanner::OnTakeDamage_Alive( const CTakeDamageInfo &info )
 
 	return (BaseClass::OnTakeDamage_Alive( info ));
 }
-	
+
+extern ConVar sv_cleanup_time;
 //------------------------------------------------------------------------------
 // Purpose:
 //------------------------------------------------------------------------------
@@ -350,14 +351,12 @@ void CNPC_CScanner::Gib( void )
 	// Add a random chance of spawning a battery...
 	if ( !HasSpawnFlags(SF_NPC_NO_WEAPON_DROP) && random->RandomFloat( 0.0f, 1.0f) < 0.3f )
 	{
-		CItem *pBattery = (CItem*)CreateEntityByName("item_battery");
+		CItem *pBattery = (CItem*)DropItem( "item_battery", GetAbsOrigin(), GetAbsAngles() );
 		if ( pBattery )
 		{
-			pBattery->SetAbsOrigin( GetAbsOrigin() );
 			pBattery->SetAbsVelocity( GetAbsVelocity() );
 			pBattery->SetLocalAngularVelocity( GetLocalAngularVelocity() );
 			pBattery->ActivateWhenAtRest();
-			pBattery->Spawn();
 		}
 	}
 

--- a/sp/src/game/server/hl2/npc_scanner.cpp
+++ b/sp/src/game/server/hl2/npc_scanner.cpp
@@ -332,7 +332,7 @@ int CNPC_CScanner::OnTakeDamage_Alive( const CTakeDamageInfo &info )
 	return (BaseClass::OnTakeDamage_Alive( info ));
 }
 
-extern ConVar sv_cleanup_time;
+extern ConVar sv_drops_cleanup_time;
 //------------------------------------------------------------------------------
 // Purpose:
 //------------------------------------------------------------------------------

--- a/sp/src/game/server/hl2/weapon_crossbow.cpp
+++ b/sp/src/game/server/hl2/weapon_crossbow.cpp
@@ -43,8 +43,6 @@
 
 extern ConVar sk_plr_dmg_crossbow;
 extern ConVar sk_npc_dmg_crossbow;
-extern ConVar sk_plr_dmg_knife_thrown;
-extern ConVar sk_npc_dmg_knife_thrown;
 
 void TE_StickyBolt( IRecipientFilter& filter, float delay,	Vector vecDirection, const Vector *origin );
 

--- a/sp/src/game/server/hl2/weapon_crossbow.cpp
+++ b/sp/src/game/server/hl2/weapon_crossbow.cpp
@@ -298,7 +298,7 @@ void CCrossbowBolt::BoltTouch( CBaseEntity *pOther )
 				data.m_vNormal = vForward;
 				data.m_nEntIndex = tr2.fraction != 1.0f;
 
-				if ( IsKnife() )
+				if ( !IsKnife() )
 					DispatchEffect( "BoltImpact", data );
 			}
 		}
@@ -399,9 +399,10 @@ void CCrossbowBolt::DoneMoving(bool stuck)
 		if ( stuck && phys != NULL )
 		{
 			phys->EnableMotion( false );
-			pWeap->SetCollisionGroup( COLLISION_GROUP_DEBRIS );
+			//pWeap->SetCollisionGroup( COLLISION_GROUP_DEBRIS );
 		}
 		pWeap->SetAbsVelocity( Vector(0, 0, 0) );
+		pWeap->AddEffects( EF_ITEM_BLINK );
 	}
 
 	Remove();

--- a/sp/src/game/server/hl2/weapon_physcannon.cpp
+++ b/sp/src/game/server/hl2/weapon_physcannon.cpp
@@ -2324,6 +2324,7 @@ void CWeaponPhysCannon::SecondaryAttack( void )
 	}
 	else
 	{
+		IPhysicsObject* phys = NULL;
 		// Otherwise pick it up
 		FindObjectResult_t result = FindObject();
 		switch ( result )
@@ -2335,6 +2336,11 @@ void CWeaponPhysCannon::SecondaryAttack( void )
 
 			// We found an object. Debounce the button
 			m_nAttack2Debounce |= pOwner->m_nButtons;
+
+			phys = m_grabController.m_attachedEntity->VPhysicsGetObject();
+			if ( phys != NULL && !phys->IsMotionEnabled() )
+				phys->EnableMotion(true);
+
 			break;
 
 		case OBJECT_NOT_FOUND:
@@ -3488,6 +3494,9 @@ bool CWeaponPhysCannon::CanPickupObject( CBaseEntity *pTarget )
 	CBasePlayer *pOwner = ToBasePlayer( GetOwner() );
 	if ( pOwner && pOwner->GetGroundEntity() == pTarget )
 		return false;
+
+	if ( FClassnameIs( pTarget, "weapon_knife" ) )
+		return true;
 
 	if ( !IsMegaPhysCannon() )
 	{

--- a/sp/src/game/server/knife_bolt.cpp
+++ b/sp/src/game/server/knife_bolt.cpp
@@ -1,0 +1,402 @@
+#include "cbase.h"
+#include "npcevent.h"
+#include "basehlcombatweapon_shared.h"
+#include "basecombatcharacter.h"
+#include "ai_basenpc.h"
+#include "player.h"
+#include "gamerules.h"
+#include "in_buttons.h"
+#include "soundent.h"
+#include "game.h"
+#include "vstdlib/random.h"
+#include "engine/IEngineSound.h"
+#include "IEffects.h"
+#include "te_effect_dispatch.h"
+#include "Sprite.h"
+#include "SpriteTrail.h"
+#include "beam_shared.h"
+#include "rumble_shared.h"
+#include "gamestats.h"
+#include "decals.h"
+#include "hl2_player.h"
+#include "func_break.h"
+#include "func_breakablesurf.h"
+
+#ifdef PORTAL
+#include "portal_util_shared.h"
+#endif
+
+// memdbgon must be the last include file in a .cpp file!!!
+#include "tier0/memdbgon.h"
+
+extern ConVar sk_plr_dmg_knife_thrown;
+extern ConVar sk_npc_dmg_knife_thrown;
+
+void TE_StickyBolt( IRecipientFilter& filter, float delay, Vector vecDirection, const Vector *origin );
+
+#define	BOLT_SKIN_NORMAL	0
+#define BOLT_SKIN_GLOW		1
+
+//-----------------------------------------------------------------------------
+// Crossbow Bolt
+//-----------------------------------------------------------------------------
+class CKnifeBolt : public CBaseCombatCharacter
+{
+	DECLARE_CLASS( CKnifeBolt, CBaseCombatCharacter );
+
+public:
+	CKnifeBolt() { };
+	~CKnifeBolt();
+
+	Class_T Classify( void ) { return CLASS_NONE; }
+
+public:
+	void Spawn( void );
+	void Precache( void );
+	void BubbleThink( void );
+	void BoltTouch( CBaseEntity *pOther );
+	bool CreateVPhysics( void );
+	unsigned int PhysicsSolidMaskForEntity() const;
+	static CKnifeBolt *BoltCreate( const Vector &vecOrigin, const QAngle &angAngles, CBasePlayer *pentOwner = NULL );
+
+protected:
+
+	bool	CreateSprites( void );
+	void	DoneMoving( bool stuck );
+
+	CHandle<CSprite>		m_pGlowSprite;
+	//CHandle<CSpriteTrail>	m_pGlowTrail;
+
+	DECLARE_DATADESC();
+	DECLARE_SERVERCLASS();
+};
+LINK_ENTITY_TO_CLASS( knife_bolt, CKnifeBolt );
+
+BEGIN_DATADESC( CKnifeBolt )
+// Function Pointers
+DEFINE_THINKFUNC( BubbleThink ),
+DEFINE_ENTITYFUNC( BoltTouch ),
+
+// These are recreated on reload, they don't need storage
+DEFINE_FIELD( m_pGlowSprite, FIELD_EHANDLE ),
+//DEFINE_FIELD( m_pGlowTrail, FIELD_EHANDLE ),
+
+END_DATADESC()
+
+IMPLEMENT_SERVERCLASS_ST( CKnifeBolt, DT_KnifeBolt )
+END_SEND_TABLE()
+
+CKnifeBolt *CKnifeBolt::BoltCreate( const Vector &vecOrigin, const QAngle &angAngles, CBasePlayer *pentOwner )
+{
+	// Create a new entity with CKnifeBolt private data
+	CKnifeBolt *pBolt = (CKnifeBolt *)CreateEntityByName( "knife_bolt" );
+	UTIL_SetOrigin( pBolt, vecOrigin );
+	pBolt->SetAbsAngles( angAngles );
+	pBolt->Spawn();
+	pBolt->SetOwnerEntity( pentOwner );
+
+	return pBolt;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+CKnifeBolt::~CKnifeBolt( void )
+{
+	if ( m_pGlowSprite )
+		UTIL_Remove( m_pGlowSprite );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+// Output : Returns true on success, false on failure.
+//-----------------------------------------------------------------------------
+bool CKnifeBolt::CreateVPhysics( void )
+{
+	// Create the object in the physics system
+	VPhysicsInitNormal( SOLID_BBOX, FSOLID_NOT_STANDABLE, false );
+
+	return true;
+}
+
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+unsigned int CKnifeBolt::PhysicsSolidMaskForEntity() const
+{
+	return MASK_PLAYERSOLID;
+
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+// Output : Returns true on success, false on failure.
+//-----------------------------------------------------------------------------
+bool CKnifeBolt::CreateSprites( void )
+{
+	// Start up the eye glow
+	m_pGlowSprite = CSprite::SpriteCreate( "sprites/light_glow02_noz.vmt", GetLocalOrigin(), false );
+
+	if ( m_pGlowSprite != NULL )
+	{
+		m_pGlowSprite->FollowEntity( this );
+		m_pGlowSprite->SetTransparency( kRenderGlow, 255, 255, 255, 128, kRenderFxNoDissipation );
+		m_pGlowSprite->SetScale( 0.2f );
+		m_pGlowSprite->TurnOff();
+	}
+
+	return true;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CKnifeBolt::Spawn( void )
+{
+	Precache();
+
+	SetModel( "models/knife_proj.mdl" );
+
+	SetMoveType( MOVETYPE_FLYGRAVITY, MOVECOLLIDE_FLY_CUSTOM );
+	UTIL_SetSize( this, -Vector( 0.3f, 0.3f, 0.3f ), Vector( 0.3f, 0.3f, 0.3f ) );
+	SetSolid( SOLID_BBOX );
+	SetGravity( 0.05f );
+
+	// Make sure we're updated if we're underwater
+	UpdateWaterState();
+
+	SetTouch( &CKnifeBolt::BoltTouch );
+
+	SetThink( &CKnifeBolt::BubbleThink );
+	SetNextThink( gpGlobals->curtime + 0.1f );
+
+	CreateSprites();
+
+	// Make us glow until we've hit the wall
+	m_nSkin = BOLT_SKIN_GLOW;
+}
+
+
+void CKnifeBolt::Precache( void )
+{
+	PrecacheModel( "models/knife_proj.mdl" );
+	PrecacheModel( "sprites/light_glow02_noz.vmt" );
+}
+
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+void CKnifeBolt::BoltTouch( CBaseEntity *pOther )
+{
+	if ( pOther->IsSolidFlagSet( FSOLID_VOLUME_CONTENTS | FSOLID_TRIGGER ) )
+	{
+		// Some NPCs are triggers that can take damage (like antlion grubs). We should hit them.
+		if ( (pOther->m_takedamage == DAMAGE_NO) || (pOther->m_takedamage == DAMAGE_EVENTS_ONLY) )
+			return;
+	}
+
+	if ( pOther->m_takedamage != DAMAGE_NO )
+	{
+		trace_t	tr, tr2;
+		tr = BaseClass::GetTouchTrace();
+		Vector vecNormalizedVel = GetAbsVelocity();
+
+		ClearMultiDamage();
+		VectorNormalize( vecNormalizedVel );
+
+		float curDamage = sk_plr_dmg_knife_thrown.GetFloat();
+
+		if ( GetOwnerEntity() && GetOwnerEntity()->IsPlayer() && pOther->IsNPC() )
+		{
+			CTakeDamageInfo	dmgInfo( this, GetOwnerEntity(), curDamage, DMG_NEVERGIB );
+			dmgInfo.AdjustPlayerDamageInflictedForSkillLevel();
+			CalculateMeleeDamageForce( &dmgInfo, vecNormalizedVel, tr.endpos, 0.7f );
+			dmgInfo.SetDamagePosition( tr.endpos );
+			DoneMoving( false );
+			pOther->DispatchTraceAttack( dmgInfo, vecNormalizedVel, &tr );
+
+			CBasePlayer *pPlayer = ToBasePlayer( GetOwnerEntity() );
+			if ( pPlayer )
+				gamestats->Event_WeaponHit( pPlayer, true, "weapon_knife", dmgInfo );
+		}
+		else
+		{
+			CTakeDamageInfo	dmgInfo( this, GetOwnerEntity(), curDamage, DMG_BULLET | DMG_NEVERGIB );
+			CalculateMeleeDamageForce( &dmgInfo, vecNormalizedVel, tr.endpos, 0.7f );
+			dmgInfo.SetDamagePosition( tr.endpos );
+			DoneMoving( false );
+			pOther->DispatchTraceAttack( dmgInfo, vecNormalizedVel, &tr );
+		}
+
+		ApplyMultiDamage();
+
+		//Adrian: keep going through the glass.
+		if ( pOther->GetCollisionGroup() == COLLISION_GROUP_BREAKABLE_GLASS )
+			return;
+
+		if ( FClassnameIs( pOther, "func_breakable" ) )
+		{
+			CBreakable* pOtherEntity = static_cast<CBreakable*>(pOther);
+			if ( pOtherEntity && (pOtherEntity->GetMaterialType() == matGlass || pOtherEntity->GetMaterialType() == matWeb) )
+				return;
+		}
+
+		if ( FClassnameIs( pOther, "func_breakable_surf" ) )
+		{
+			CBreakableSurface* pOtherEntity = static_cast<CBreakableSurface*>(pOther);
+			if ( pOtherEntity && (pOtherEntity->GetMaterialType() == matGlass || pOtherEntity->GetMaterialType() == matWeb) )
+				return;
+		}
+
+		if ( !pOther->IsAlive() )
+		{
+			// We killed it! 
+			const surfacedata_t *pdata = physprops->GetSurfaceData( tr.surface.surfaceProps );
+			if ( pdata->game.material == CHAR_TEX_GLASS )
+			{
+				return;
+			}
+		}
+
+		SetAbsVelocity( Vector( 0, 0, 0 ) );
+
+		// play body "thwack" sound
+		EmitSound( "Weapon_Crossbow.BoltHitBody" );
+
+		Vector vForward;
+
+		AngleVectors( GetAbsAngles(), &vForward );
+		VectorNormalize( vForward );
+
+		UTIL_TraceLine( GetAbsOrigin(), GetAbsOrigin() + vForward * 128, MASK_BLOCKLOS, pOther, COLLISION_GROUP_NONE, &tr2 );
+
+		if ( tr2.fraction != 1.0f )
+		{
+			//			NDebugOverlay::Box( tr2.endpos, Vector( -16, -16, -16 ), Vector( 16, 16, 16 ), 0, 255, 0, 0, 10 );
+			//			NDebugOverlay::Box( GetAbsOrigin(), Vector( -16, -16, -16 ), Vector( 16, 16, 16 ), 0, 0, 255, 0, 10 );
+
+			if ( tr2.m_pEnt == NULL || (tr2.m_pEnt && tr2.m_pEnt->GetMoveType() == MOVETYPE_NONE) )
+			{
+				CEffectData	data;
+
+				data.m_vOrigin = tr2.endpos;
+				data.m_vNormal = vForward;
+				data.m_nEntIndex = tr2.fraction != 1.0f;
+			}
+		}
+	}
+	else
+	{
+		trace_t	tr;
+		tr = BaseClass::GetTouchTrace();
+
+		// See if we struck the world
+		if ( pOther->GetMoveType() == MOVETYPE_NONE && !(tr.surface.flags & SURF_SKY) && !(tr.contents & CONTENTS_PLAYERCLIP) )
+		{
+			EmitSound( "Weapon_Crossbow.BoltHitWorld" );
+
+			// if what we hit is static architecture, can stay around for a while.
+			Vector vecDir = GetAbsVelocity();
+			float speed = VectorNormalize( vecDir );
+
+			// See if we should reflect off this surface
+			float hitDot = DotProduct( tr.plane.normal, -vecDir );
+
+			if ( (hitDot < 0.5f) && (speed > 100) )
+			{
+				Vector vReflection = 2.0f * tr.plane.normal * hitDot + vecDir;
+
+				QAngle reflectAngles;
+
+				VectorAngles( vReflection, reflectAngles );
+
+				SetLocalAngles( reflectAngles );
+
+				SetAbsVelocity( vReflection * speed * 0.75f );
+
+				// Start to sink faster
+				SetGravity( 1.0f );
+			}
+			else
+			{
+				//FIXME: We actually want to stick (with hierarchy) to what we've hit
+				SetMoveType( MOVETYPE_NONE );
+
+				Vector vForward;
+
+				AngleVectors( GetAbsAngles(), &vForward );
+				VectorNormalize( vForward );
+
+				CEffectData	data;
+
+				data.m_vOrigin = tr.endpos;
+				data.m_vNormal = vForward;
+				data.m_nEntIndex = 0;
+
+				UTIL_ImpactTrace( &tr, DMG_BULLET );
+
+				// The shallower the angle, the less of chance of sticking.
+				DoneMoving( random->RandomFloat( 0.5 ) <= hitDot );
+
+				if ( m_pGlowSprite != NULL )
+				{
+					m_pGlowSprite->TurnOn();
+					m_pGlowSprite->FadeAndDie( 3.0f );
+				}
+			}
+
+			// Shoot some sparks
+			if ( UTIL_PointContents( GetAbsOrigin() ) != CONTENTS_WATER )
+			{
+				g_pEffects->Sparks( GetAbsOrigin() );
+			}
+		}
+		else if ( tr.surface.flags & SURF_SKY || tr.contents & CONTENTS_PLAYERCLIP )
+			DoneMoving( false );
+		else
+		{
+			UTIL_ImpactTrace( &tr, DMG_BULLET );
+			DoneMoving( false );
+		}
+	}
+}
+
+void CKnifeBolt::DoneMoving( bool stuck )
+{
+	auto angle = GetAbsAngles();
+	// The weapon model is reversed for some reason.
+	angle[0] += 180;
+	auto pWeap = (CBaseCombatWeapon*)CBaseEntity::CreateNoSpawn( "weapon_knife", GetAbsOrigin(), angle );
+	pWeap->AddSpawnFlags( SF_NORESPAWN );
+	DispatchSpawn( pWeap );
+
+	auto phys = pWeap->VPhysicsGetObject();
+	if ( stuck && phys != NULL )
+	{
+		phys->EnableMotion( false );
+		//pWeap->SetCollisionGroup( COLLISION_GROUP_DEBRIS );
+	}
+	pWeap->SetAbsVelocity( Vector( 0, 0, 0 ) );
+	pWeap->AddEffects( EF_ITEM_BLINK );
+
+	Remove();
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CKnifeBolt::BubbleThink( void )
+{
+	QAngle angNewAngles;
+
+	VectorAngles( GetAbsVelocity(), angNewAngles );
+	SetAbsAngles( angNewAngles );
+
+	SetNextThink( gpGlobals->curtime + 0.1f );
+
+	// Make danger sounds out in front of me, to scare snipers back into their hole
+	CSoundEnt::InsertSound( SOUND_DANGER_SNIPERONLY, GetAbsOrigin() + GetAbsVelocity() * 0.2, 120.0f, 0.5f, this, SOUNDENT_CHANNEL_REPEATED_DANGER );
+
+	if ( GetWaterLevel() == 0 )
+		return;
+
+	UTIL_BubbleTrail( GetAbsOrigin() - GetAbsVelocity() * 0.1f, GetAbsOrigin(), 5 );
+}

--- a/sp/src/game/server/physics_prop_ragdoll.cpp
+++ b/sp/src/game/server/physics_prop_ragdoll.cpp
@@ -22,6 +22,7 @@
 #include "hierarchy.h"
 #include "firefightreloaded/fr_ragdoll.h"
 #include "hl2/hl2_gamerules.h"
+#include "firefightreloaded/cleanup_manager.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -386,7 +387,7 @@ void CRagdollProp::OnPhysGunPickup( CBasePlayer *pPhysGunUser, PhysGunPickup_t r
 
 	if ( HasSpawnFlags( SF_RAGDOLLPROP_USE_LRU_RETIREMENT ) )
 	{
-		s_RagdollLRU.MoveToTopOfLRU( this );
+		CCleanupManager::AddRagdoll(this);
 	}
 
 	if ( !HasSpawnFlags( SF_PHYSPROP_ENABLE_ON_PHYSCANNON ) )
@@ -424,9 +425,7 @@ void CRagdollProp::OnPhysGunDrop( CBasePlayer *pPhysGunUser, PhysGunDrop_t Reaso
 	}
 
 	if ( HasSpawnFlags( SF_RAGDOLLPROP_USE_LRU_RETIREMENT ) )
-	{
-		s_RagdollLRU.MoveToTopOfLRU( this );
-	}
+		CCleanupManager::AddRagdoll( this );
 
 	// Make sure it's interactive debris for at most 5 seconds
 	if ( GetCollisionGroup() == COLLISION_GROUP_INTERACTIVE_DEBRIS )
@@ -1467,7 +1466,7 @@ CBaseEntity *CreateServerRagdoll( CBaseAnimating *pAnimating, int forceBone, con
 	else if ( bUseLRURetirement )
 	{
 		pRagdoll->AddSpawnFlags( SF_RAGDOLLPROP_USE_LRU_RETIREMENT );
-		s_RagdollLRU.MoveToTopOfLRU( pRagdoll );
+		CCleanupManager::AddRagdoll( pRagdoll );
 	}
 
 	// Tracker 22598:  If we don't set the OBB mins/maxs to something valid here, then the client will have a zero sized hull

--- a/sp/src/game/server/player.cpp
+++ b/sp/src/game/server/player.cpp
@@ -3794,7 +3794,12 @@ bool CBasePlayer::CanPickupObject( CBaseEntity *pObject, float massLimit, float 
 
 	//Must move with physics
 	if ( pObject->GetMoveType() != MOVETYPE_VPHYSICS )
+	{
+		auto weapon = dynamic_cast<CBaseCombatWeapon*>(pObject);
+		if ( weapon != NULL )
+			return true;
 		return false;
+	}
 
 	IPhysicsObject *pList[VPHYSICS_MAX_OBJECT_LIST_COUNT];
 	int count = pObject->VPhysicsGetObjectList( pList, ARRAYSIZE(pList) );

--- a/sp/src/game/shared/baseentity_shared.cpp
+++ b/sp/src/game/shared/baseentity_shared.cpp
@@ -23,6 +23,7 @@
 #ifdef CLIENT_DLL
 	#include "c_te_effect_dispatch.h"
 #else
+	#include "util.h"
 	#include "te_effect_dispatch.h"
 	#include "soundent.h"
 	#include "iservervehicle.h"
@@ -1163,7 +1164,7 @@ void CBaseEntity::VPhysicsUpdate( IPhysicsObject *pPhysics )
 			{
 				if ( CheckEmitReasonablePhysicsSpew() )
 				{
-					Warning( "Ignoring unreasonable position (%f,%f,%f) from vphysics! (entity %s)\n", origin.x, origin.y, origin.z, GetDebugName() );
+					Warning( "Removing entity with unreasonable position (%f,%f,%f) from vphysics! (entity %s)\n", origin.x, origin.y, origin.z, GetDebugName() );
 				}
 			}
 

--- a/sp/src/game/shared/baseentity_shared.cpp
+++ b/sp/src/game/shared/baseentity_shared.cpp
@@ -1162,9 +1162,10 @@ void CBaseEntity::VPhysicsUpdate( IPhysicsObject *pPhysics )
 			}
 			else
 			{
-				if ( CheckEmitReasonablePhysicsSpew() )
+				if ( CheckEmitReasonablePhysicsSpew() && !IsPlayer() )
 				{
 					Warning( "Removing entity with unreasonable position (%f,%f,%f) from vphysics! (entity %s)\n", origin.x, origin.y, origin.z, GetDebugName() );
+					this->Remove();
 				}
 			}
 

--- a/sp/src/game/shared/baseentity_shared.cpp
+++ b/sp/src/game/shared/baseentity_shared.cpp
@@ -1166,6 +1166,7 @@ void CBaseEntity::VPhysicsUpdate( IPhysicsObject *pPhysics )
 				{
 					Warning( "Removing entity with unreasonable position (%f,%f,%f) from vphysics! (entity %s)\n", origin.x, origin.y, origin.z, GetDebugName() );
 					this->Remove();
+					return;
 				}
 			}
 

--- a/sp/src/game/shared/physics_main_shared.cpp
+++ b/sp/src/game/shared/physics_main_shared.cpp
@@ -1923,17 +1923,13 @@ bool CBaseEntity::PhysicsRunThink( thinkmethods_t thinkMethod )
 	// Fire the rest of 'em
 	for ( int i = 0; i < m_aThinkFunctions.Count(); i++ )
 	{
-#ifdef _DEBUG
 		// Set the context
 		m_iCurrentThinkContext = i;
-#endif
 
 		bAlive = PhysicsRunSpecificThink( i, m_aThinkFunctions[i].m_pfnThink );
 
-#ifdef _DEBUG
 		// Clear our context
 		m_iCurrentThinkContext = NO_THINK_CONTEXT;
-#endif
 
 		if ( !bAlive )
 			return false;

--- a/sp/src/game/shared/ragdoll_shared.cpp
+++ b/sp/src/game/shared/ragdoll_shared.cpp
@@ -831,15 +831,15 @@ void CRagdollLRURetirement::Update( float frametime ) // EPISODIC VERSION
 			IPhysicsObject* pObject = pRagdoll->VPhysicsGetObject();
 			if ( pRagdoll->GetEffectEntity() || (pObject && !pObject->IsAsleep()) )
 				continue;
-		}
 
 #ifdef CLIENT_DLL
-		m_LRU[i]->SUB_Remove();
+			m_LRU[i]->SUB_Remove();
 #else
-		m_LRU[i]->SUB_StartFadeOut( 0, true, "CleanUp" );
+			m_LRU[i]->SUB_StartFadeOut( 0, true, "CleanUp" );
 #endif
-		--m_iRagdollCount;
-		m_LRU.Remove( i );
+			--m_iRagdollCount;
+			m_LRU.Remove( i );
+		}
 	}
 }
 

--- a/sp/src/game/shared/ragdoll_shared.h
+++ b/sp/src/game/shared/ragdoll_shared.h
@@ -79,56 +79,6 @@ struct ragdollparams_t
 	bool		fixedConstraints;
 };
 
-//-----------------------------------------------------------------------------
-// This hooks the main game systems callbacks to allow the AI system to manage memory
-//-----------------------------------------------------------------------------
-class CRagdollLRURetirement : public CAutoGameSystemPerFrame
-{
-public:
-	CRagdollLRURetirement( char const *name ) : CAutoGameSystemPerFrame( name )
-	{
-	}
-
-	// Methods of IGameSystem
-	virtual void Update( float frametime );
-	virtual void FrameUpdatePostEntityThink( void );
-
-	// Move it to the top of the LRU
-	void MoveToTopOfLRU( CBaseAnimating *pRagdoll, bool bImportant = false );
-	void SetMaxRagdollCount( int iMaxCount ){ m_iMaxRagdolls = iMaxCount; }
-
-	virtual void LevelInitPreEntity( void );
-	int CountRagdolls( bool bOnlySimulatingRagdolls ) { return bOnlySimulatingRagdolls ? m_iSimulatedRagdollCount : m_iRagdollCount; }
-
-private:
-	typedef CHandle<CBaseAnimating> CRagdollHandle;
-	CUtlLinkedList< CRagdollHandle > m_LRU; 
-	CUtlLinkedList< CRagdollHandle > m_LRUImportantRagdolls; 
-
-	int m_iMaxRagdolls;
-	int m_iSimulatedRagdollCount;
-	int m_iRagdollCount;
-};
-
-extern CRagdollLRURetirement s_RagdollLRU;
-
-// Manages ragdolls fading for the low violence versions
-class CRagdollLowViolenceManager
-{
-public:
-	CRagdollLowViolenceManager(){ m_bLowViolence = false; }
-	// Turn the low violence ragdoll stuff off if we're in the HL2 Citadel maps because
-	// the player has the super gravity gun and fading ragdolls will break things.
-	void SetLowViolence( const char *pMapName );
-	bool IsLowViolence( void ){ return m_bLowViolence; }
-
-private:
-	bool m_bLowViolence;
-};
-
-extern CRagdollLowViolenceManager g_RagdollLVManager;
-
-
 bool RagdollCreate( ragdoll_t &ragdoll, const ragdollparams_t &params, IPhysicsEnvironment *pPhysEnv );
 
 void RagdollActivate( ragdoll_t &ragdoll, vcollide_t *pCollide, int modelIndex, bool bForceWake = true );


### PR DESCRIPTION
As part of my ongoing struggle keeping the number of entities low, I have introduced a rather aggressive clean up mechanism for ragdolls and gibs. The defaults are 32 for ragdolls and gibs, but this is tunable via cvars. This has allowed me to play for over an hour without problems regarding too many entities.