### PR TITLE
Cleanup breakthrough

### DIFF
--- a/sp/src/game/server/SMMOD/mapadd.cpp
+++ b/sp/src/game/server/SMMOD/mapadd.cpp
@@ -239,7 +239,7 @@ bool CMapAdd::HandleRemoveEnitity( KeyValues *mapaddValue)
 				while ( (pent = gEntList.FindEntityByClassname( pent, STRING(str) )) != 0 )
 					UTIL_Remove( pent );
 			}
-			if ( AllocPooledString( pEntKeyValuesRemove->GetName() ) == AllocPooledString( "targetname" ) )
+			else if ( AllocPooledString( pEntKeyValuesRemove->GetName() ) == AllocPooledString( "targetname" ) )
 			{
 				CBaseEntity* pent = NULL;
 				while ( (pent = gEntList.FindEntityByName( pent, STRING(str) )) != 0 )

--- a/sp/src/game/server/SMMOD/mapadd.cpp
+++ b/sp/src/game/server/SMMOD/mapadd.cpp
@@ -182,7 +182,12 @@ bool CMapAdd::HandleSpecialEnitity( KeyValues *specialEntity)
 
 bool CMapAdd::HandleRemoveEnitity( KeyValues *mapaddValue)
 {
-	if (AllocPooledString(mapaddValue->GetName()) == AllocPooledString("remove:sphere"))
+	static const auto CLASSNAME = AllocPooledString( "classname" );
+	static const auto TARGETNAME = AllocPooledString( "targetname" );
+	static const auto REMOVEALL = AllocPooledString( "remove:all" );
+	static const auto REMOVESPHERE = AllocPooledString( "remove:sphere" );
+
+	if (AllocPooledString(mapaddValue->GetName()) == REMOVESPHERE)
 	{
 		auto pEntKeyValues = mapaddValue->FindKey( "entities" );
 		if ( pEntKeyValues == NULL )
@@ -205,14 +210,12 @@ bool CMapAdd::HandleRemoveEnitity( KeyValues *mapaddValue)
 			{
 				if ( ppEnts[i] == NULL )
 					continue;
-				if (name == AllocPooledString("classname")
-					&& str == AllocPooledString(ppEnts[i]->GetClassname()))
+				if (name == CLASSNAME && str == AllocPooledString(ppEnts[i]->GetClassname()))
 				{
 					UTIL_Remove(ppEnts[i]);
 					continue;
 				}
-				else if (name == AllocPooledString("targetname")
-					&& str == ppEnts[i]->GetEntityName())
+				else if (name == TARGETNAME	&& str == ppEnts[i]->GetEntityName())
 				{
 					UTIL_Remove(ppEnts[i]);
 					continue;
@@ -222,7 +225,7 @@ bool CMapAdd::HandleRemoveEnitity( KeyValues *mapaddValue)
 		}
 		return true;
 	}
-	else if ( AllocPooledString( mapaddValue->GetName() ) == AllocPooledString( "remove:all" ) )
+	else if ( AllocPooledString( mapaddValue->GetName() ) == REMOVEALL )
 	{
 		auto pEntKeyValues = mapaddValue->FindKey( "entities" );
 		if ( pEntKeyValues == NULL )
@@ -233,13 +236,13 @@ bool CMapAdd::HandleRemoveEnitity( KeyValues *mapaddValue)
 		{
 			const auto name = AllocPooledString( pEntKeyValuesRemove->GetName() );
 			const auto str = AllocPooledString( pEntKeyValuesRemove->GetString() );
-			if ( name == AllocPooledString( "classname" ) )
+			if ( name == CLASSNAME )
 			{
 				CBaseEntity* pent = NULL;
 				while ( (pent = gEntList.FindEntityByClassname( pent, STRING(str) )) != 0 )
 					UTIL_Remove( pent );
 			}
-			else if ( AllocPooledString( pEntKeyValuesRemove->GetName() ) == AllocPooledString( "targetname" ) )
+			else if ( name == TARGETNAME )
 			{
 				CBaseEntity* pent = NULL;
 				while ( (pent = gEntList.FindEntityByName( pent, STRING(str) )) != 0 )

--- a/sp/src/game/server/firefightreloaded/cleanup_manager.cpp
+++ b/sp/src/game/server/firefightreloaded/cleanup_manager.cpp
@@ -54,7 +54,8 @@ void CCleanupManager::Add( Handles& handles, EHANDLE handle, const ConVar& var, 
 	if ( var.GetInt() < 0 || handle == NULL )
 		return;
 
-	while ( handles.Count() >= var.GetInt() )
+	handles.AddToTail( handle );
+	while ( handles.Count() > var.GetInt() )
 	{
 		auto head = handles.Head();
 		handles.Remove( 0 );
@@ -63,7 +64,6 @@ void CCleanupManager::Add( Handles& handles, EHANDLE handle, const ConVar& var, 
 		else
 			DevMsg( "Manager using cvar %s had a null entry.", var.GetName() );
 	}
-	handles.AddToTail( handle );
 }
 
 bool CCleanupManager::Remove( Handles& handles, EHANDLE handle )

--- a/sp/src/game/server/firefightreloaded/cleanup_manager.cpp
+++ b/sp/src/game/server/firefightreloaded/cleanup_manager.cpp
@@ -60,17 +60,15 @@ void CCleanupManager::Add( Handles& handles, EHANDLE handle, const ConVar& var, 
 		handles.Remove( 0 );
 		if ( head != NULL )
 			func( head );
+		else
+			DevMsg( "Manager using cvar %s had a null entry.", var.GetName() );
 	}
 	handles.AddToTail( handle );
 }
 
 bool CCleanupManager::Remove( Handles& handles, EHANDLE handle )
 {
-	int idx = handles.Find( handle );
-	if ( idx < 0 )
-		return false;
-	handles[idx].Term();
-	return true;
+	return handles.FindAndRemove( handle );
 }
 
 void CCleanupManager::AddCombineMine( EHANDLE mine )
@@ -96,6 +94,16 @@ void CCleanupManager::AddThrownKnife( EHANDLE knife )
 bool CCleanupManager::RemoveCombineMine( EHANDLE mine )
 {
 	return Remove( GetManager()->m_CombineMines, mine );
+}
+
+bool CCleanupManager::RemoveGib( EHANDLE knife )
+{
+	return Remove( GetManager()->m_Gibs, knife );
+}
+
+bool CCleanupManager::RemoveRagdoll( EHANDLE mine )
+{
+	return Remove( GetManager()->m_Ragdolls, mine );
 }
 
 bool CCleanupManager::RemoveThrownKnife( EHANDLE knife )

--- a/sp/src/game/server/firefightreloaded/cleanup_manager.h
+++ b/sp/src/game/server/firefightreloaded/cleanup_manager.h
@@ -37,6 +37,8 @@ public:
 	static void AddThrownKnife( EHANDLE knife );
 
 	static bool RemoveCombineMine( EHANDLE mine );
+	static bool RemoveGib( EHANDLE gib );
+	static bool RemoveRagdoll( EHANDLE ragdoll );
 	static bool RemoveThrownKnife( EHANDLE knife );
 
 	static void Shutdown();

--- a/sp/src/game/server/firefightreloaded/monstermaker_firefight.cpp
+++ b/sp/src/game/server/firefightreloaded/monstermaker_firefight.cpp
@@ -433,10 +433,16 @@ void CNPCMakerFirefight::MakeNPC()
 	if (!CanMakeNPC())
 		return;
 
-	bool rarity = sk_spawnrareenemies.GetBool() && CanMakeRareNPC() && random->RandomInt( 1, m_nRareNPCRarity ) == 1;
-	auto entry = g_npcLoader->GetRandomEntry( rarity );
+	const CRandNPCLoader::SpawnEntry_t* entry = NULL;
+	if ( sk_spawnrareenemies.GetBool() && CanMakeRareNPC() && random->RandomInt( 1, m_nRareNPCRarity ) == 1 )
+		entry = g_npcLoader->GetRandomEntry( true ); // Try to choose a rare NPC.
 	if ( entry == NULL )
-		return;
+	{
+		// Couldn't choose a rare one (or a rare NPC was not allowed) so try a normal one.
+		entry = g_npcLoader->GetRandomEntry( false );
+	}
+	if ( entry == NULL )
+		return; // Eep. Couldn't choose anything.
 
 	const char* pRandomName = entry->classname;
 	CAI_BaseNPC* pent = (CAI_BaseNPC*)CreateEntityByName(pRandomName);

--- a/sp/src/game/server/firefightreloaded/randnpcloader.cpp
+++ b/sp/src/game/server/firefightreloaded/randnpcloader.cpp
@@ -66,7 +66,7 @@ bool CRandNPCLoader::Load()
 	return true;
 }
 
-const CRandNPCLoader::SpawnEntry_t* CRandNPCLoader::GetRandomEntry(bool rarity) const
+const CRandNPCLoader::SpawnEntry_t* CRandNPCLoader::GetRandomEntry(bool isRare) const
 {
 	int count = 0;
 	int largestPlayerLevel = GetLargestLevel();
@@ -75,14 +75,14 @@ const CRandNPCLoader::SpawnEntry_t* CRandNPCLoader::GetRandomEntry(bool rarity) 
 	const auto end = m_Entries.end();
 	for ( auto iter = m_Entries.begin(); iter != end; ++iter )
 	{
-		if ( largestPlayerLevel >= iter->minPlayerLevel && iter->isRare == rarity)
+		if ( largestPlayerLevel >= iter->minPlayerLevel && iter->isRare == isRare)
 			++count;
 	}
 
 	int choice = random->RandomInt( 1, count );
 	for ( auto iter = m_Entries.begin(); iter != end; ++iter )
 	{
-		if ( largestPlayerLevel >= iter->minPlayerLevel && iter->isRare == rarity)
+		if ( largestPlayerLevel >= iter->minPlayerLevel && iter->isRare == isRare)
 		{
 			if ( choice == 1 )
 				return iter;

--- a/sp/src/game/server/firefightreloaded/randnpcloader.h
+++ b/sp/src/game/server/firefightreloaded/randnpcloader.h
@@ -51,7 +51,7 @@ public:
 
 	bool Load();
 	bool AddEntries( KeyValues *kv );
-	const SpawnEntry_t* GetRandomEntry(bool rarity) const;
+	const SpawnEntry_t* GetRandomEntry(bool isRare) const;
 
 private:
 	static int GetLargestLevel();

--- a/sp/src/game/server/firefightreloaded/weapon_knife.cpp
+++ b/sp/src/game/server/firefightreloaded/weapon_knife.cpp
@@ -405,3 +405,9 @@ void CWeaponKnife::Equip( CBaseCombatCharacter *pOwner )
 	CCleanupManager::RemoveThrownKnife( this );
 	BaseClass::Equip( pOwner );
 }
+
+void CWeaponKnife::UpdateOnRemove()
+{
+	CCleanupManager::RemoveThrownKnife( this );
+	BaseClass::UpdateOnRemove();
+}

--- a/sp/src/game/server/firefightreloaded/weapon_knife.h
+++ b/sp/src/game/server/firefightreloaded/weapon_knife.h
@@ -49,6 +49,8 @@ public:
 
 	int			OnTakeDamage( const CTakeDamageInfo& info );
 
+	void UpdateOnRemove();
+
 	virtual void Equip( CBaseCombatCharacter *pOwner );
 
 	// Animation event

--- a/sp/src/game/server/gib.cpp
+++ b/sp/src/game/server/gib.cpp
@@ -15,6 +15,7 @@
 #include "vstdlib/random.h"
 #include "ai_utils.h"
 #include "EntityFlame.h"
+#include "firefightreloaded/cleanup_manager.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -757,6 +758,11 @@ void CGib::Spawn(const char *szGibModel, float flLifetime)
 	SetNextThink(gpGlobals->curtime + m_lifeTime);
 }
 
+void CGib::UpdateOnRemove()
+{
+	CCleanupManager::RemoveGib( this );
+	BaseClass::UpdateOnRemove();
+}
 
 LINK_ENTITY_TO_CLASS(gib, CGib);
 

--- a/sp/src/game/server/gib.h
+++ b/sp/src/game/server/gib.h
@@ -63,6 +63,8 @@ public:
 	virtual void OnPhysGunDrop(CBasePlayer *pPhysGunUser, PhysGunDrop_t reason);
 	virtual	CBasePlayer *HasPhysicsAttacker(float dt);
 
+	virtual void UpdateOnRemove();
+
 	void SetSprite(CBaseEntity *pSprite)
 	{
 		m_hSprite = pSprite;

--- a/sp/src/game/server/hl2/combine_mine.cpp
+++ b/sp/src/game/server/hl2/combine_mine.cpp
@@ -1255,6 +1255,12 @@ void CBounceBomb::OnPhysGunPickup( CBasePlayer *pPhysGunUser, PhysGunPickup_t re
 	}
 }
 
+void CBounceBomb::UpdateOnRemove()
+{
+	CCleanupManager::RemoveCombineMine( this );
+	BaseClass::UpdateOnRemove();
+}
+
 
 LINK_ENTITY_TO_CLASS( bounce_bomb, CBounceBomb );
 LINK_ENTITY_TO_CLASS( combine_bouncemine, CBounceBomb );

--- a/sp/src/game/server/hl2/combine_mine.h
+++ b/sp/src/game/server/hl2/combine_mine.h
@@ -53,6 +53,7 @@ public:
 	int OnTakeDamage( const CTakeDamageInfo &info );
 	bool IsFriend( CBaseEntity *pEntity );
 
+	void UpdateOnRemove();
 	void UpdateLight( bool bTurnOn, unsigned int r, unsigned int g, unsigned int b, unsigned int a );
 	bool IsLightOn() { return m_hSprite.Get() != NULL; }
 

--- a/sp/src/game/server/physics_prop_ragdoll.cpp
+++ b/sp/src/game/server/physics_prop_ragdoll.cpp
@@ -251,6 +251,8 @@ void CRagdollProp::CalcRagdollSize( void )
 
 void CRagdollProp::UpdateOnRemove( void )
 {
+	CCleanupManager::RemoveRagdoll( this );
+
 	for ( int i = 0; i < m_ragdoll.listCount; i++ )
 	{
 		if ( m_ragdoll.list[i].pObject )


### PR DESCRIPTION
Hopefully the last major change to cleaning up. The naive queue system I had for cleaning up would not take into consideration entities that had been removed by other means and so there was often less managed entities in the queue than the max. This would cause some older gibs/ragdolls/mines/etc to be cleaned up even when there was plenty of space. I now have a mechanism to automatically remove entities that were removed by other methods from the cleanup lists. That was really the only major issue I had to address the cleanup.

Also made some changes to the NPC spawning.