### PR TITLE
Default to SteamDeck mode (unless the user really doesn't want it).

### DIFF
--- a/sp/src/game/client/cdll_client_int.cpp
+++ b/sp/src/game/client/cdll_client_int.cpp
@@ -383,7 +383,7 @@ const bool IsSteamDeck()
 	if ( pszSteamDeckEnv && *pszSteamDeckEnv )
 		return atoi( pszSteamDeckEnv ) != 0;
 
-	return false;
+	return true;
 }
 #endif
 


### PR DESCRIPTION
I would leave a way to use the older ui. One good thing about it is an issue where the new ui elements can sometimes take precedence over the console and I don't think the old UI allowed that.