### PR TITLE
Reset position of items, weapons, and FF crates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ compile_commands.json
 !sourcesdk_def.mak
 *.vsidx
 sp/src/.vs/*
+.vs
 sp/game/firefightreloaded/cfg/user_sp.scr
 sp/game/firefightreloaded/cfg/steam_autocloud.vdf
 sp/src/lib/public/fgdlib.lib

--- a/sp/src/game/server/baseanimating.cpp
+++ b/sp/src/game/server/baseanimating.cpp
@@ -33,6 +33,9 @@
 
 ConVar ai_sequence_debug( "ai_sequence_debug", "0" );
 
+extern ConVar sv_weapon_respawn_time;
+ConVar sv_reset_position_dist("sv_reset_position_dist", "64", FCVAR_ARCHIVE, "Distance outside of which position is always reset.");
+
 class CIKSaveRestoreOps : public CClassPtrSaveRestoreOps
 {
 	// save data type interface
@@ -215,7 +218,10 @@ DEFINE_INPUTFUNC( FIELD_VECTOR, "SetModelScale", InputSetModelScale ),
 
 DEFINE_FIELD( m_fBoneCacheFlags, FIELD_SHORT ),
 
-	END_DATADESC()
+DEFINE_FIELD(m_vecSpawnOrigin, FIELD_VECTOR),
+DEFINE_FIELD(m_angSpawnAngles, FIELD_VECTOR),
+
+END_DATADESC()
 
 // Sendtable for fields we don't want to send to clientside animating entities
 BEGIN_SEND_TABLE_NOBASE( CBaseAnimating, DT_ServerAnimationData )
@@ -380,6 +386,9 @@ void CBaseAnimating::OnRestore()
 //-----------------------------------------------------------------------------
 void CBaseAnimating::Spawn()
 {
+	m_vecSpawnOrigin = GetAbsOrigin();
+	m_angSpawnAngles = GetLocalAngles();
+
 	BaseClass::Spawn();
 }
 
@@ -3596,4 +3605,39 @@ CStudioHdr *CBaseAnimating::OnNewModel()
 	}
 
 	return hdr;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Relocate weapon if it potentially can't be gotten by the player anymore.
+// Return true if repositioning occurred.
+//-----------------------------------------------------------------------------// 
+bool CBaseAnimating::ResetPosition(bool force)
+{
+	// Don't bother if we don't have any physics objects since we can't move.
+	auto phys = VPhysicsGetObject();
+	if (phys == nullptr || phys->GetGameFlags() & FVPHYSICS_PLAYER_HELD)
+		return false;
+
+	// If we're too far (or being forced), reset.
+	auto curOrigin = GetAbsOrigin();
+	if (!force && m_vecSpawnOrigin.DistTo(curOrigin) <= sv_reset_position_dist.GetFloat())
+	{
+		// We're not too far away yet, but we still might not be accessible. Estimate whether
+		// the player can still touch the item by tracing a line to the object from the spawn
+		// origin and seeing if there any impediments; if so, reset.
+		Ray_t ray;
+		ray.Init(m_vecSpawnOrigin, curOrigin);
+		trace_t trace;
+		UTIL_TraceRay(ray, MASK_PLAYERSOLID_BRUSHONLY, this,
+			COLLISION_GROUP_PLAYER, &trace);
+		if (!trace.DidHit())
+			return false;
+	}
+
+  phys->EnableMotion(false);
+  SetLocalAngularVelocity(vec3_angle);
+  Teleport(&m_vecSpawnOrigin, &m_angSpawnAngles, &vec3_origin);
+  phys->EnableMotion(true);
+  phys->Wake();
+  return true;
 }

--- a/sp/src/game/server/baseanimating.h
+++ b/sp/src/game/server/baseanimating.h
@@ -330,6 +330,8 @@ public:
 
 	bool PrefetchSequence( int iSequence );
 
+	virtual bool ResetPosition(bool force = false);
+
 private:
 	void LockStudioHdr();
 	void UnlockStudioHdr();
@@ -414,6 +416,9 @@ protected:
 
 public:
 	COutputEvent m_OnIgnite;
+
+	Vector					m_vecSpawnOrigin;
+	QAngle					m_angSpawnAngles;
 
 private:
 	CStudioHdr			*m_pStudioHdr;

--- a/sp/src/game/server/firefightreloaded/monstermaker_firefight.cpp
+++ b/sp/src/game/server/firefightreloaded/monstermaker_firefight.cpp
@@ -147,17 +147,16 @@ void CNPCMakerFirefight::Precache(void)
 {
 	BaseClass::Precache();
 
-	if ( g_npcLoader == NULL )
+	if (g_npcLoader == nullptr)
 	{
 		g_npcLoader = new CRandNPCLoader;
-		g_npcLoader->Load();
-
-		float setSpawnTime = g_npcLoader->m_Settings.spawnTime;
-		if (setSpawnTime && setSpawnTime != TIME_SETBYHAMMER)
-		{
-			m_flSpawnFrequency = setSpawnTime;
-		}
+		AssertFatal(g_npcLoader != nullptr);
+		AssertFatal(g_npcLoader->Load());
 	}
+
+	float setSpawnTime = g_npcLoader->m_Settings.spawnTime;
+	if (setSpawnTime != 0 && setSpawnTime != TIME_SETBYHAMMER)
+		m_flSpawnFrequency = setSpawnTime;
 
 	int nWeapons = ARRAYSIZE(g_Weapons);
 	for (int i = 0; i < nWeapons; ++i)

--- a/sp/src/game/server/firefightreloaded/randnpcloader.cpp
+++ b/sp/src/game/server/firefightreloaded/randnpcloader.cpp
@@ -20,6 +20,7 @@ void dumpspawnlist_cb()
 {
 	extern CRandNPCLoader* g_npcLoader;
 
+	ConMsg("m_Settings.spawnTime: %f\n", g_npcLoader->m_Settings.spawnTime);
 	for ( auto& iter : g_npcLoader->m_Entries )
 	{
 		ConMsg( "[%p] name=\"%s\", %s minPlayerLevel=%d npcAttributePreset=%d grenades=[%d, %d] weight=%f, totalEquipWeight=%f\n",
@@ -110,6 +111,8 @@ bool CRandNPCLoader::Load()
 			m_Settings.spawnTime = settings->GetFloat("spawntime", TIME_SETBYHAMMER);
 		}
 	}
+	else
+		m_Settings.spawnTime = TIME_SETBYHAMMER;
 
 	AddEntries( pKV );
 

--- a/sp/src/game/server/items.h
+++ b/sp/src/game/server/items.h
@@ -56,6 +56,7 @@ public:
 	unsigned int PhysicsSolidMaskForEntity( void ) const;
 
 	virtual CBaseEntity* Respawn( void );
+	void ResetPositionThink();
 	virtual void ItemTouch( CBaseEntity *pOther );
 	virtual void Materialize( void );
 	virtual bool MyTouch( CBasePlayer *pPlayer ) { return false; };
@@ -72,10 +73,6 @@ public:
 
 	virtual int	ObjectCaps() { return BaseClass::ObjectCaps() | FCAP_IMPULSE_USE | FCAP_WCEDIT_POSITION; };
 	virtual void Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value );
-	Vector	GetOriginalSpawnOrigin( void ) { return m_vOriginalSpawnOrigin;	}
-	QAngle	GetOriginalSpawnAngles( void ) { return m_vOriginalSpawnAngles;	}
-	void	SetOriginalSpawnOrigin( const Vector& origin ) { m_vOriginalSpawnOrigin = origin; }
-	void	SetOriginalSpawnAngles( const QAngle& angles ) { m_vOriginalSpawnAngles = angles; }
 	bool	CreateItemVPhysicsObject( void );
 	virtual bool	ItemCanBeTouchedByPlayer( CBasePlayer *pPlayer );
 
@@ -93,9 +90,6 @@ private:
 	COutputEvent m_OnPlayerTouch;
 	COutputEvent m_OnCacheInteraction;
 	
-	Vector		m_vOriginalSpawnOrigin;
-	QAngle		m_vOriginalSpawnAngles;
-
 	IPhysicsConstraint		*m_pConstraint;
 };
 

--- a/sp/src/game/shared/basecombatweapon_shared.cpp
+++ b/sp/src/game/shared/basecombatweapon_shared.cpp
@@ -3085,6 +3085,7 @@ BEGIN_DATADESC( CBaseCombatWeapon )
 	DEFINE_THINKFUNC( AttemptToMaterialize ),
 	DEFINE_THINKFUNC( DestroyItem ),
 	DEFINE_THINKFUNC( SetPickupTouch ),
+	DEFINE_THINKFUNC( ResetPositionThink ),
 
 	DEFINE_THINKFUNC( HideThink ),
 	DEFINE_INPUTFUNC( FIELD_VOID, "HideWeapon", InputHideWeapon ),

--- a/sp/src/game/shared/basecombatweapon_shared.h
+++ b/sp/src/game/shared/basecombatweapon_shared.h
@@ -19,6 +19,7 @@
 #include "weapon_proficiency.h"
 #include "utlmap.h"
 #include "particle_parse.h"
+#include "convar.h"
 
 #if defined( CLIENT_DLL )
 #define CBaseCombatWeapon C_BaseCombatWeapon
@@ -473,6 +474,8 @@ public:
 
 	virtual CDmgAccumulator	*GetDmgAccumulator( void ) { return NULL; }
 
+	void ResetPositionThink();
+
 // Client only methods
 #else
 
@@ -651,7 +654,7 @@ private:
 	bool					m_bStandardHudHintDisplayed;	// Have we displayed a store HUD hint since this weapon was deployed?
 	float					m_flHudHintPollTime;	// When to poll the weapon again for whether it should display a hud hint.
 	float					m_flHudHintMinDisplayTime; // if the hint is squelched before this, reset my counter so we'll display it again.
-	
+
 	// Server only
 #if !defined( CLIENT_DLL )
 


### PR DESCRIPTION
From time to time, weapons, items, and FF crates are blown far out of the player's reach. There is now a mechanism that addresses this issue. There's also some fixes for spawnTime still taking on NaNs.